### PR TITLE
BI-672 - Implement POST /variables in Breedbase

### DIFF
--- a/db/00132/AddTraitCvterms.pm
+++ b/db/00132/AddTraitCvterms.pm
@@ -70,8 +70,10 @@ sub patch {
                     'trait_method_name',
                     'trait_method_description',
                     'trait_method_class',
-                    'trait_method_formula'
-
+                    'trait_method_formula',
+                    'trait_decimal_places',
+                    'trait_categories_label',
+                    'trait_categories_value'
                 ]
         );
 

--- a/db/00132/AddTraitCvterms.pm
+++ b/db/00132/AddTraitCvterms.pm
@@ -1,0 +1,109 @@
+#!/usr/bin/env perl
+
+
+=head1 NAME
+
+ AddTraitCvterms
+
+=head1 SYNOPSIS
+
+mx-run ThisPackageName [options] -H hostname -D dbname -u username [-F]
+
+this is a subclass of L<CXGN::Metadata::Dbpatch>
+see the perldoc of parent class for more details.
+
+=head1 DESCRIPTION
+
+This patch adds system cvterms that are needed for cvtermprops to store BrAPI variable data.
+
+This subclass uses L<Moose>. The parent class uses L<MooseX::Runnable>
+
+=head1 AUTHOR
+
+ Nick Palladino<np398@cornell.edu>
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2010 Boyce Thompson Institute for Plant Research
+
+This program is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut
+
+
+package AddTraitCvterms;
+
+use Moose;
+use Try::Tiny;
+use Bio::Chado::Schema;
+
+extends 'CXGN::Metadata::Dbpatch';
+
+
+has '+description' => ( default => <<'' );
+This patch will add system cvterms required for storing BrAPI variable data
+
+has '+prereq' => (
+    default => sub {
+        [],
+    },
+);
+
+sub patch {
+    my $self=shift;
+
+    print STDOUT "Executing the patch:\n " .   $self->name . ".\n\nDescription:\n  ".  $self->description . ".\n\nExecuted by:\n " .  $self->username . " .";
+    print STDOUT "\nChecking if this db_patch was executed before or if previous db_patches have been executed.\n";
+    print STDOUT "\nExecuting the SQL commands.\n";
+
+    my %cvterms =
+        (
+            'brapi_external_reference' =>
+                [
+                    'reference_id',
+                    'reference_source',
+                ],
+
+            'trait_property' =>
+                [
+                    'trait_method_name',
+                    'trait_method_description',
+                    'trait_method_class',
+                    'trait_method_formula'
+
+                ]
+        );
+
+    my $schema = Bio::Chado::Schema->connect( sub { $self->dbh->clone } );
+
+    my $coderef = sub {
+
+        foreach my $cv_name ( keys  %cvterms  ) {
+            print "\nKEY = $cv_name \n\n";
+            my @cvterm_names = @{$cvterms{ $cv_name } }  ;
+
+            foreach  my $cvterm_name ( @cvterm_names ) {
+                print "cvterm= $cvterm_name \n";
+                my $new_cvterm = $schema->resultset("Cv::Cvterm")->create_with(
+                    {
+                        name => $cvterm_name,
+                        cv   => $cv_name,
+                    });
+            }
+        }
+    };
+
+    try {
+        $schema->txn_do($coderef);
+
+    } catch {
+        die "Load failed! " . $_ .  "\n" ;
+    };
+
+    print "You're done!\n";
+}
+
+####
+1; #
+####

--- a/lib/CXGN/BrAPI/v1/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v1/ObservationVariables.pm
@@ -210,8 +210,11 @@ sub search {
 			}
 		);
 
+		# Don't convert since POST /variables writes correct scale types (not sure if this breaks Breedbase UI stuff?)
+		my $trait_format = $trait->format;
+
 		# Convert our breedbase data types to BrAPI data types.
-		my $trait_format = $self->convert_datatype_to_brapi($trait->format, scalar(@brapi_categories));
+		#my $trait_format = $self->convert_datatype_to_brapi($trait->format, scalar(@brapi_categories));
 
 		# Note: Breedbase does not have a concept of 'methods'.
 		# Note: Breedbase does not have a concept of 'scale'. The values populated in scale are values from cvprop.

--- a/lib/CXGN/BrAPI/v2/ExternalReferences.pm
+++ b/lib/CXGN/BrAPI/v2/ExternalReferences.pm
@@ -1,0 +1,173 @@
+package CXGN::BrAPI::v2::ExternalReferences;
+
+use Moose;
+use Data::Dumper;
+use Try::Tiny;
+use List::Util 'max';
+
+has 'bcs_schema' => (
+    isa => 'Bio::Chado::Schema',
+    is => 'rw',
+    required => 1,
+);
+
+has 'external_references' => (
+    is => 'ro',
+    isa => 'ArrayRef[HashRef[Str]]',
+);
+
+has 'dbxref_id' => (
+    isa => 'Int',
+    is => 'rw',
+    required => 1,
+);
+
+has 'cv_id' => (
+    isa => 'Int',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        # get cv_id for external references
+        my $cv_id = $self->bcs_schema->resultset("Cv::Cv")->find(
+            {
+                name => 'brapi_external_reference'
+            },
+            { key => 'cv_c1' }
+        )->get_column('cv_id');
+        return $cv_id;
+    }
+);
+
+has 'reference_id' => (
+    isa => 'Int',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        # get cvterm id for reference_id
+        my $reference_id = $self->bcs_schema->resultset("Cv::Cvterm")->find(
+            {
+                name        => 'reference_id',
+                cv_id       => $self->cv_id,
+                is_obsolete => 0
+            },
+            { key => 'cvterm_c1' }
+        )->get_column('cvterm_id');
+        return $reference_id;
+    }
+);
+
+has 'reference_source_id' => (
+    isa => 'Int',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        # get cvterm id for reference_id
+        my $reference_source = $self->bcs_schema->resultset("Cv::Cvterm")->find(
+            {
+                name        => 'reference_source',
+                cv_id       => $self->cv_id,
+                is_obsolete => 0
+            },
+            { key => 'cvterm_c1' }
+        )->get_column('cvterm_id');
+        return $reference_source;
+    }
+);
+
+has 'references_db' => (
+    isa => 'ArrayRef[HashRef[Str]]',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my %references;
+
+        my $props = $self->bcs_schema()->resultset("Cv::Dbxrefprop")->search(
+            {
+                dbxref_id => $self->dbxref_id()
+            },
+            {order_by => { -asc => 'rank' }}
+        );
+
+        while (my $prop = $props->next()){
+            my $reference = $references{$prop->get_column('rank')};
+            if ($prop->get_column('type_id') == $self->reference_id) {
+                $reference->{'referenceID'} = $prop->get_column('value');
+            }
+            if ($prop->get_column('type_id') == $self->reference_source_id) {
+                $reference->{'referenceSource'} = $prop->get_column('value');
+            }
+
+            $references{$prop->get_column('rank')}=$reference;
+        }
+
+        my $ref = \%references;
+        my $maxkey = max keys %$ref;
+        my @array = @{$ref}{0 .. $maxkey};
+        return \@array;
+    }
+);
+
+sub store {
+    my $self = shift;
+    my $schema = $self->bcs_schema();
+    my $dbxref_id = $self->dbxref_id();
+
+    my @references = @{$self->external_references()};
+    my $rank = 0;
+
+    # get cv_id for external references
+    my $cv_id = $self->cv_id;
+    # get cvterm ids for reference_id & reference_source
+    my $reference_id = $self->reference_id;
+    my $reference_source = $self->reference_source_id;
+
+    my $coderef = sub {
+
+        foreach my $reference (@references) {
+            my $id = $reference->{'referenceID'};
+            my $source = $reference->{'referenceSource'};
+
+            # write external reference info to dbxrefprop
+            my $prop_id = $schema->resultset("Cv::Dbxrefprop")->create(
+                {
+                    dbxref_id => $dbxref_id,
+                    type_id   => $reference_id,
+                    value     => $id,
+                    rank      => $rank
+                }
+            );
+
+            my $prop_source = $schema->resultset("Cv::Dbxrefprop")->create(
+                {
+                    dbxref_id => $dbxref_id,
+                    type_id   => $reference_source,
+                    value     => $source,
+                    rank      => $rank
+                }
+            );
+
+            $rank++;
+        }
+    };
+
+    my $transaction_error;
+
+    try {
+        $schema->txn_do($coderef);
+    } catch {
+        $transaction_error =  $_;
+    };
+
+    if ($transaction_error) {
+        return {error => "External References transaction error trying to write to db"}
+    }
+
+    return { success => "External References added successfully" };
+
+}
+
+1;

--- a/lib/CXGN/BrAPI/v2/Locations.pm
+++ b/lib/CXGN/BrAPI/v2/Locations.pm
@@ -192,9 +192,10 @@ sub store {
     my $schema = $self->bcs_schema();
     my @location_ids;
 
-	if (!$user_id) {
-		return CXGN::BrAPI::JSONResponse->return_error($self->status, sprintf('You must login and have permission to access this BrAPI call.'));
-	}
+	# TODO: removed check for use with bi-api for now without token
+	#if (!$user_id) {
+	#	return CXGN::BrAPI::JSONResponse->return_error($self->status, sprintf('You must login and have permission to access this BrAPI call.'));
+	#}
 
 	foreach my $params (@{$data}) {
 		my $id = $params->{locationDbId} || undef;

--- a/lib/CXGN/BrAPI/v2/Methods.pm
+++ b/lib/CXGN/BrAPI/v2/Methods.pm
@@ -1,0 +1,224 @@
+package CXGN::BrAPI::v2::Methods;
+
+use Moose;
+use Data::Dumper;
+use Try::Tiny;
+use List::Util 'max';
+
+has 'bcs_schema' => (
+    isa => 'Bio::Chado::Schema',
+    is => 'rw',
+    required => 1,
+);
+
+has 'method' => (
+    is => 'ro',
+    isa => 'HashRef[Any]',
+);
+
+has 'cvterm_id' => (
+    isa => 'Int',
+    is => 'rw',
+    required => 1,
+);
+
+has 'cv_id' => (
+    isa => 'Int',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my $cv_id = $self->bcs_schema->resultset("Cv::Cv")->find(
+            {
+                name => 'trait_property'
+            },
+            { key => 'cv_c1' }
+        )->get_column('cv_id');
+        return $cv_id;
+    }
+);
+
+has 'method_name_id' => (
+    isa => 'Int',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my $method_name_id = $self->bcs_schema->resultset("Cv::Cvterm")->find(
+            {
+                name        => 'trait_method_name',
+                cv_id       => $self->cv_id,
+                is_obsolete => 0
+            },
+            { key => 'cvterm_c1' }
+        )->get_column('cvterm_id');
+        return $method_name_id;
+    }
+);
+
+has 'method_description_id' => (
+    isa => 'Int',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my $method_description_id = $self->bcs_schema->resultset("Cv::Cvterm")->find(
+            {
+                name        => 'trait_method_description',
+                cv_id       => $self->cv_id,
+                is_obsolete => 0
+            },
+            { key => 'cvterm_c1' }
+        )->get_column('cvterm_id');
+        return $method_description_id;
+    }
+);
+
+has 'method_class_id' => (
+    isa => 'Int',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my $method_class_id = $self->bcs_schema->resultset("Cv::Cvterm")->find(
+            {
+                name        => 'trait_method_class',
+                cv_id       => $self->cv_id,
+                is_obsolete => 0
+            },
+            { key => 'cvterm_c1' }
+        )->get_column('cvterm_id');
+        return $method_class_id;
+    }
+);
+
+has 'method_formula_id' => (
+    isa => 'Int',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my $method_formula_id = $self->bcs_schema->resultset("Cv::Cvterm")->find(
+            {
+                name        => 'trait_method_formula',
+                cv_id       => $self->cv_id,
+                is_obsolete => 0
+            },
+            { key => 'cvterm_c1' }
+        )->get_column('cvterm_id');
+        return $method_formula_id;
+    }
+);
+
+has 'method_db' => (
+    isa => 'HashRef[Str]',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my %method;
+
+        my $props = $self->bcs_schema()->resultset("Cv::Cvtermprop")->search(
+            {
+                cvterm_id => $self->cvterm_id()
+            },
+            {order_by => { -asc => 'rank' }}
+        );
+
+        my $ref = \%method;
+
+        while (my $prop = $props->next()){
+            if ($prop->get_column('type_id') == $self->method_name_id) {
+                $ref->{'methodName'} = $prop->get_column('value');
+            }
+            if ($prop->get_column('type_id') == $self->method_description_id) {
+                $ref->{'description'} = $prop->get_column('value');
+            }
+            if ($prop->get_column('type_id') == $self->method_class_id) {
+                $ref->{'methodClass'} = $prop->get_column('value');
+            }
+            if ($prop->get_column('type_id') == $self->method_formula_id) {
+                $ref->{'formula'} = $prop->get_column('value');
+            }
+        }
+
+        return $ref;
+    }
+);
+
+sub store {
+    my $self = shift;
+    my $schema = $self->bcs_schema();
+    my $cvterm_id = $self->cvterm_id();
+    my $method = $self->method();
+    my $cv_id = $self->cv_id;
+
+    my $method_name_id = $self->method_name_id;
+    my $method_description_id = $self->method_description_id;
+    my $method_class_id = $self->method_class_id;
+    my $method_formula_id = $self->method_formula_id;
+
+    my $coderef = sub {
+
+        my $method_name = $method->{'methodName'};
+        my $method_description = $method->{'description'};
+        my $method_class = $method->{'methodClass'};
+        my $method_formula = $method->{'formula'};
+
+        my $prop_name = $schema->resultset("Cv::Cvtermprop")->create(
+            {
+                cvterm_id => $cvterm_id,
+                type_id   => $method_name_id,
+                value     => $method_name,
+                rank      => 0
+            }
+        );
+
+        my $prop_description = $schema->resultset("Cv::Cvtermprop")->create(
+            {
+                cvterm_id => $cvterm_id,
+                type_id   => $method_description_id,
+                value     => $method_description,
+                rank      => 0
+            }
+        );
+
+        my $prop_class = $schema->resultset("Cv::Cvtermprop")->create(
+            {
+                cvterm_id => $cvterm_id,
+                type_id   => $method_class_id,
+                value     => $method_class,
+                rank      => 0
+            }
+        );
+
+        if ($method_formula) {
+            my $prop_formula = $schema->resultset("Cv::Cvtermprop")->create(
+                {
+                    cvterm_id => $cvterm_id,
+                    type_id   => $method_formula_id,
+                    value     => $method_formula,
+                    rank      => 0
+                }
+            );
+        }
+
+    };
+
+    my $transaction_error;
+
+    try {
+        $schema->txn_do($coderef);
+    } catch {
+        $transaction_error =  $_;
+    };
+
+    if ($transaction_error) {
+        return {error => "Method transaction error trying to write to db"}
+    }
+
+    return { success => "Method added successfully" };
+
+}
+
+1;

--- a/lib/CXGN/BrAPI/v2/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationVariables.pm
@@ -186,7 +186,7 @@ sub get_query {
     my $limit = $page_size;
     my $offset = $page*$page_size;
     my $total_count = 0;
-    my $q = "SELECT cvterm.cvterm_id, cvterm.name, cvterm.definition, db.name, db.db_id, db.url, dbxref.dbxref_id, dbxref.accession, array_agg(cvtermsynonym.synonym), cvterm.is_obsolete, count(cvterm.cvterm_id) OVER() AS full_count FROM cvterm ".
+    my $q = "SELECT cvterm.cvterm_id, cvterm.name, cvterm.definition, db.name, db.db_id, db.url, dbxref.dbxref_id, dbxref.accession, array_agg(cvtermsynonym.synonym) filter (where cvtermsynonym.synonym is not null), cvterm.is_obsolete, count(cvterm.cvterm_id) OVER() AS full_count FROM cvterm ".
         "JOIN dbxref USING(dbxref_id) ".
         "JOIN db using(db_id) ".
         "LEFT JOIN cvtermsynonym using(cvterm_id) ". # left join to include non-synoynm variables, may break field book due to bug

--- a/lib/CXGN/BrAPI/v2/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationVariables.pm
@@ -360,6 +360,19 @@ sub detail {
     return CXGN::BrAPI::JSONResponse->return_success(\%result, $pagination, \@data_files, $status, 'Observationvariable search result constructed');
 }
 
+sub store {
+
+    my $self = shift;
+    my $page_size = $self->page_size;
+    my $page = $self->page;
+
+    my %result;
+    my $count = 0;
+    my $pagination = CXGN::BrAPI::Pagination->pagination_response($count,$page_size,$page);
+    return CXGN::BrAPI::JSONResponse->return_success( \%result, $pagination, undef, $self->status(), $count . " Variables were saved.");
+
+}
+
 sub observation_variable_ontologies {
     my $self = shift;
     my $inputs = shift;

--- a/lib/CXGN/BrAPI/v2/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationVariables.pm
@@ -284,19 +284,19 @@ sub get_query {
         };
     }
 
-    #my $pagination;
-    #my %result;
-    #if ($array) {
-        my ($data_window, $pagination) = CXGN::BrAPI::Pagination->paginate_array(\@variables, $page_size, $page);
-        my %result = (data => $data_window);
-    #} else {
-        #my %result = (\@variables);
-        #$pagination = CXGN::BrAPI::Pagination->pagination_response($total_count,$page_size,$page);
-    #}
-    # my %result = (data=>\@data);
+    my $pagination;
+    my %result;
     my @data_files;
 
-    return CXGN::BrAPI::JSONResponse->return_success(\%result, $pagination, \@data_files, $status, 'Observationvariable search result constructed');
+    if ($array) {
+        my $data_window;
+        ($data_window, $pagination) = CXGN::BrAPI::Pagination->paginate_array(\@variables, $page_size, $page);
+        %result = (data => $data_window);
+        return CXGN::BrAPI::JSONResponse->return_success(\%result, $pagination, \@data_files, $status, 'Observationvariable search result constructed');
+    } else {
+        $pagination = CXGN::BrAPI::Pagination->pagination_response($total_count,$page_size,$page);
+        return CXGN::BrAPI::JSONResponse->return_success(@variables[0], $pagination, \@data_files, $status, 'Observationvariable search result constructed');
+    }
 
 }
 

--- a/lib/CXGN/BrAPI/v2/Programs.pm
+++ b/lib/CXGN/BrAPI/v2/Programs.pm
@@ -177,9 +177,10 @@ sub store {
     my $status = $self->status;
     my $schema = $self->bcs_schema();
 
-    if (!$user_id) {
-		return CXGN::BrAPI::JSONResponse->return_error($self->status, sprintf('You must login and have permission to access this BrAPI call.'));
-	}
+	# TODO: Disabled auth for use with bi-api
+    #if (!$user_id) {
+	#	return CXGN::BrAPI::JSONResponse->return_error($self->status, sprintf('You must login and have permission to access this BrAPI call.'));
+	#}
 	my @program_ids;
 
 	foreach my $params (@{$data}) {
@@ -213,9 +214,10 @@ sub update {
     my $status = $self->status;
     my $schema = $self->bcs_schema();
 
-    if (!$user_id) {
-		return CXGN::BrAPI::JSONResponse->return_error($self->status, sprintf('You must login and have permission to access this BrAPI call.'));
-	}
+	# TODO: Disabled auth for use with bi-api
+    #if (!$user_id) {
+	#	return CXGN::BrAPI::JSONResponse->return_error($self->status, sprintf('You must login and have permission to access this BrAPI call.'));
+	#}
 	my @program_ids;
 
 	my $name = $params->{programName} || undef;

--- a/lib/CXGN/BrAPI/v2/Programs.pm
+++ b/lib/CXGN/BrAPI/v2/Programs.pm
@@ -184,15 +184,19 @@ sub store {
 	my @program_ids;
 
 	foreach my $params (@{$data}) {
-		my $name = $params->{programName} || undef;
-		my $desc = $params->{objective} || undef;
 
-		my $p = CXGN::BreedersToolbox::Projects->new( { schema => $schema });
+		my $name = $params->{programName} || undef;
+		my $desc = $params->{objective} || 'N/A'; # needs an objective due to db constraints
+
+		my $p = CXGN::BreedersToolbox::Projects->new({ schema => $schema });
 
 		my $new_program = $p->new_breeding_program($name, $desc);
 
-		print STDERR "New program is ".Dumper($new_program)."\n";
+		if ($new_program->{'error'}) {
+			return CXGN::BrAPI::JSONResponse->return_error($self->status, sprintf('Program %s was not stored.', $name));
+		}
 
+		print STDERR "New program is " . Dumper($new_program) . "\n";
 		push @program_ids, $new_program;
 
 	}
@@ -221,7 +225,7 @@ sub update {
 	my @program_ids;
 
 	my $name = $params->{programName} || undef;
-	my $desc = $params->{objective} || undef;
+	my $desc = $params->{objective} || 'N/A'; # needs an objective due to db constraints
 	my $id = $params->{programDbId} || undef;
 
 	my $program = $schema->resultset('Project::Project')->find({project_id => $id});

--- a/lib/CXGN/BrAPI/v2/Scales.pm
+++ b/lib/CXGN/BrAPI/v2/Scales.pm
@@ -1,0 +1,357 @@
+package CXGN::BrAPI::v2::Scales;
+
+use Moose;
+use Data::Dumper;
+use Try::Tiny;
+use List::Util 'max';
+
+has 'bcs_schema' => (
+    isa => 'Bio::Chado::Schema',
+    is => 'rw',
+    required => 1,
+);
+
+has 'scale' => (
+    is => 'ro',
+    isa => 'HashRef[Any]',
+);
+
+has 'cvterm_id' => (
+    isa => 'Int',
+    is => 'rw',
+    required => 1,
+);
+
+has 'cv_id' => (
+    isa => 'Int',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my $cv_id = $self->bcs_schema->resultset("Cv::Cv")->find(
+            {
+                name => 'trait_property'
+            },
+            { key => 'cv_c1' }
+        )->get_column('cv_id');
+        return $cv_id;
+    }
+);
+
+has 'scale_categories_id' => (
+    isa => 'Int',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my $scale_categories_id = $self->bcs_schema->resultset("Cv::Cvterm")->find(
+            {
+                name        => 'trait_categories',
+                cv_id       => $self->cv_id,
+                is_obsolete => 0
+            },
+            { key => 'cvterm_c1' }
+        )->get_column('cvterm_id');
+        return $scale_categories_id;
+    }
+);
+
+has 'scale_categories_label_id' => (
+    isa => 'Int',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my $scale_categories_label_id = $self->bcs_schema->resultset("Cv::Cvterm")->find(
+            {
+                name        => 'trait_categories_label',
+                cv_id       => $self->cv_id,
+                is_obsolete => 0
+            },
+            { key => 'cvterm_c1' }
+        )->get_column('cvterm_id');
+        return $scale_categories_label_id;
+    }
+);
+
+has 'scale_categories_value_id' => (
+    isa => 'Int',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my $scale_categories_value_id = $self->bcs_schema->resultset("Cv::Cvterm")->find(
+            {
+                name        => 'trait_categories_value',
+                cv_id       => $self->cv_id,
+                is_obsolete => 0
+            },
+            { key => 'cvterm_c1' }
+        )->get_column('cvterm_id');
+        return $scale_categories_value_id;
+    }
+);
+
+
+
+has 'scale_format_id' => (
+    isa => 'Int',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my $scale_format_id = $self->bcs_schema->resultset("Cv::Cvterm")->find(
+            {
+                name        => 'trait_format',
+                cv_id       => $self->cv_id,
+                is_obsolete => 0
+            },
+            { key => 'cvterm_c1' }
+        )->get_column('cvterm_id');
+        return $scale_format_id;
+    }
+);
+
+has 'scale_maximum_id' => (
+    isa => 'Int',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my $scale_maximum_id = $self->bcs_schema->resultset("Cv::Cvterm")->find(
+            {
+                name        => 'trait_maximum',
+                cv_id       => $self->cv_id,
+                is_obsolete => 0
+            },
+            { key => 'cvterm_c1' }
+        )->get_column('cvterm_id');
+        return $scale_maximum_id;
+    }
+);
+
+has 'scale_minimum_id' => (
+    isa => 'Int',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my $scale_minimum_id = $self->bcs_schema->resultset("Cv::Cvterm")->find(
+            {
+                name        => 'trait_minimum',
+                cv_id       => $self->cv_id,
+                is_obsolete => 0
+            },
+            { key => 'cvterm_c1' }
+        )->get_column('cvterm_id');
+        return $scale_minimum_id;
+    }
+);
+
+has 'scale_decimal_places_id' => (
+    isa => 'Int',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+        my $scale_decimal_places_id = $self->bcs_schema->resultset("Cv::Cvterm")->find(
+            {
+                name        => 'trait_decimal_places',
+                cv_id       => $self->cv_id,
+                is_obsolete => 0
+            },
+            { key => 'cvterm_c1' }
+        )->get_column('cvterm_id');
+        return $scale_decimal_places_id;
+    }
+);
+
+has 'scale_db' => (
+    isa => 'HashRef[Any]',
+    is => 'ro',
+    lazy => 1,
+    default => sub {
+        my $self = shift;
+
+        my %scale;
+        my %categories;
+
+        my $props = $self->bcs_schema()->resultset("Cv::Cvtermprop")->search(
+            {
+                cvterm_id => $self->cvterm_id()
+            },
+            {order_by => { -asc => 'rank' }}
+        );
+
+        my $scale_ref = \%scale;
+
+        while (my $prop = $props->next()){
+            my $category = $categories{$prop->get_column('rank')};
+
+            if ($prop->get_column('type_id') == $self->scale_categories_label_id) {
+                $category->{'label'} = $prop->get_column('value');
+            }
+
+            if ($prop->get_column('type_id') == $self->scale_categories_value_id) {
+                $category->{'value'} = $prop->get_column('value');
+            }
+
+            $categories{$prop->get_column('rank')}=$category;
+
+            if ($prop->get_column('type_id') == $self->scale_format_id) {
+                $scale_ref->{'dataType'} = $prop->get_column('value');
+            }
+            if ($prop->get_column('type_id') == $self->scale_decimal_places_id) {
+                $scale_ref->{'decimalPlaces'} = $prop->get_column('value')+0;
+            }
+
+            if ($prop->get_column('type_id') == $self->scale_maximum_id) {
+                $scale_ref->{'validValues'}{'max'} = $prop->get_column('value')+0;
+            }
+            if ($prop->get_column('type_id') == $self->scale_minimum_id) {
+                $scale_ref->{'validValues'}{'min'} = $prop->get_column('value')+0;
+            }
+        }
+
+        my $ref = \%categories;
+        my $maxkey = max keys %$ref;
+        my @array = @{$ref}{0 .. $maxkey};
+        $scale_ref->{'validValues'}{'categories'} = \@array;
+
+        return $scale_ref;
+    }
+);
+
+sub store {
+    my $self = shift;
+    my $schema = $self->bcs_schema();
+    my $cvterm_id = $self->cvterm_id();
+    my $scale = $self->scale();
+    my @scale_categories;
+
+    if ($self->scale->{'validValues'}{'categories'}) {
+        @scale_categories = @{$self->scale->{'validValues'}{'categories'}};
+    }
+
+    my $scale_format_id = $self->scale_format_id;
+    my $scale_decimal_places_id = $self->scale_decimal_places_id;
+    my $scale_categories_id = $self->scale_categories_id;
+    my $scale_categories_label_id = $self->scale_categories_label_id;
+    my $scale_categories_value_id = $self->scale_categories_value_id;
+    my $scale_maximum_id = $self->scale_maximum_id;
+    my $scale_minimum_id = $self->scale_minimum_id;
+
+    my $scale_format = $scale->{'dataType'};
+    my $scale_decimal_places = $scale->{'decimalPlaces'};
+    my $scale_categories = $scale->{'validValues'}{'categories'};
+    my $scale_maximum = $scale->{'validValues'}{'max'};
+    my $scale_minimum = $scale->{'validValues'}{'min'};
+
+    my $rank = 0;
+    my $categories_v1;
+
+    my $coderef = sub {
+
+        # write category values for v2
+        foreach my $category (@scale_categories) {
+            my $label = $category->{'label'};
+            my $value = $category->{'value'};
+
+            # write external reference info to dbxrefprop
+            my $prop_id = $schema->resultset("Cv::Cvtermprop")->create(
+                {
+                    cvterm_id => $cvterm_id,
+                    type_id   => $scale_categories_label_id,
+                    value     => $label,
+                    rank      => $rank
+                }
+            );
+
+            my $prop_source = $schema->resultset("Cv::Cvtermprop")->create(
+                {
+                    cvterm_id => $cvterm_id,
+                    type_id   => $scale_categories_value_id,
+                    value     => $value,
+                    rank      => $rank
+                }
+            );
+
+            $rank++;
+
+            # form categories string for v1 call
+            $categories_v1=$categories_v1.$label."=".$value."/";
+        }
+
+        my $format = $schema->resultset("Cv::Cvtermprop")->create(
+            {
+                cvterm_id => $cvterm_id,
+                type_id   => $scale_format_id,
+                value     => $scale_format,
+                rank      => 0
+            }
+        );
+
+        if (defined($scale_decimal_places) && length($scale_decimal_places)) {
+            my $decimal_places = $schema->resultset("Cv::Cvtermprop")->create(
+                {
+                    cvterm_id => $cvterm_id,
+                    type_id   => $scale_decimal_places_id,
+                    value     => $scale_decimal_places,
+                    rank      => 0
+                }
+            );
+        }
+
+        # write in format used by v1 calls
+        if ($scale_categories) {
+            my $categories = $schema->resultset("Cv::Cvtermprop")->create(
+                {
+                    cvterm_id => $cvterm_id,
+                    type_id   => $scale_categories_id,
+                    value     => $categories_v1,
+                    rank      => 0
+                }
+            );
+        }
+
+        if (defined($scale_maximum) && length($scale_maximum)) {
+            my $maximum = $schema->resultset("Cv::Cvtermprop")->create(
+                {
+                    cvterm_id => $cvterm_id,
+                    type_id   => $scale_maximum_id,
+                    value     => $scale_maximum,
+                    rank      => 0
+                }
+            );
+        }
+
+        if (defined($scale_minimum) && length($scale_minimum)) {
+            my $minimum = $schema->resultset("Cv::Cvtermprop")->create(
+                {
+                    cvterm_id => $cvterm_id,
+                    type_id   => $scale_minimum_id,
+                    value     => $scale_minimum,
+                    rank      => 0
+                }
+            );
+        }
+
+    };
+
+    my $transaction_error;
+
+    try {
+        $schema->txn_do($coderef);
+    } catch {
+        $transaction_error =  $_;
+    };
+
+    if ($transaction_error) {
+        return {error => "Scale transaction error trying to write to db"}
+    }
+
+    return { success => "Scale added successfully" };
+
+}
+
+1;

--- a/lib/CXGN/BrAPI/v2/Scales.pm
+++ b/lib/CXGN/BrAPI/v2/Scales.pm
@@ -190,13 +190,13 @@ has 'scale_db' => (
 
             if ($prop->get_column('type_id') == $self->scale_categories_label_id) {
                 $category->{'label'} = $prop->get_column('value');
+                $categories{$prop->get_column('rank')}=$category;
             }
 
             if ($prop->get_column('type_id') == $self->scale_categories_value_id) {
                 $category->{'value'} = $prop->get_column('value');
+                $categories{$prop->get_column('rank')}=$category;
             }
-
-            $categories{$prop->get_column('rank')}=$category;
 
             if ($prop->get_column('type_id') == $self->scale_format_id) {
                 $scale_ref->{'dataType'} = $prop->get_column('value');
@@ -213,10 +213,12 @@ has 'scale_db' => (
             }
         }
 
-        my $ref = \%categories;
-        my $maxkey = max keys %$ref;
-        my @array = @{$ref}{0 .. $maxkey};
-        $scale_ref->{'validValues'}{'categories'} = \@array;
+        if (%categories) {
+            my $ref = \%categories;
+            my $maxkey = max keys %$ref;
+            my @array = @{$ref}{0 .. $maxkey};
+            $scale_ref->{'validValues'}{'categories'} = \@array;
+        }
 
         return $scale_ref;
     }

--- a/lib/CXGN/BrAPI/v2/Scales.pm
+++ b/lib/CXGN/BrAPI/v2/Scales.pm
@@ -250,7 +250,7 @@ sub store {
     my $scale_minimum = $scale->{'validValues'}{'min'};
 
     my $rank = 0;
-    my $categories_v1;
+    my $categories_v1 = "";
 
     my $coderef = sub {
 

--- a/lib/CXGN/BrAPI/v2/ServerInfo.pm
+++ b/lib/CXGN/BrAPI/v2/ServerInfo.pm
@@ -71,7 +71,7 @@ sub search {
 		[['application/json'],['GET'], 'ontologies',['2.0']],
 		[['application/json'],['GET'], 'traits',['2.0']],
 		[['application/json'],['GET'], 'traits/{traitDbId}',['2.0']],
-		[['application/json'],['GET'], 'variables',['2.0']],
+		[['application/json'],['GET', 'POST'], 'variables',['2.0']],
 		[['application/json'],['GET'], 'variables/{observationVariableDbId}',['2.0']],
 		[['application/json'],['POST'],'search/variables',['2.0']],
 		[['application/json'],['GET'], 'search/variables/{searchResultsDbId}',['2.0']],

--- a/lib/CXGN/Trait.pm
+++ b/lib/CXGN/Trait.pm
@@ -394,7 +394,10 @@ sub store {
 		$new_term->add_synonym($synonym);
 	}
 
-	return { success => "Variable added successfully\n", id=>undef };
+	$self->cvterm_id($variable_of_id);
+	$self->cvterm($cvterm);
+
+	return { success => "Variable added successfully\n", variable=>$self };
 }
 
 # TODO: common utilities somewhere, used by Location also

--- a/lib/CXGN/Trait.pm
+++ b/lib/CXGN/Trait.pm
@@ -6,6 +6,7 @@ use Data::Dumper;
 use Try::Tiny;
 use CXGN::BrAPI::v2::ExternalReferences;
 use CXGN::BrAPI::v2::Methods;
+use CXGN::BrAPI::v2::Scales;
 
 ## to do: add concept of trait short name; provide alternate constructors for term, shortname, and synonyms etc.
 
@@ -278,6 +279,11 @@ has 'method' => (
 	is  => 'rw'
 );
 
+has 'scale' => (
+	isa => 'Maybe[HashRef[Any]]',
+	is  => 'rw'
+);
+
 
 sub BUILD { 
     #print STDERR "BUILDING...\n";
@@ -295,6 +301,7 @@ sub BUILD {
 		$self->synonyms($self->synonyms());
 		$self->external_references($self->external_references());
 		$self->method($self->method());
+		$self->scale($self->scale());
     }
 
     #my $cvterm = $self->bcs_schema()->resultset("Cv::Cvterm")->find( { cvterm_id => $self->cvterm_id() });
@@ -434,6 +441,17 @@ sub store {
 		}
 
 		# TODO: save scale properties
+		my $scale = CXGN::BrAPI::v2::Scales->new({
+			bcs_schema => $self->bcs_schema,
+			scale => $self->scale,
+			cvterm_id => $new_term->get_column('cvterm_id')
+		});
+
+		$scale->store();
+
+		if ($scale->{'error'}) {
+			return {error => $scale->{'error'}};
+		}
 
 		# TODO: save method properties
 		my $m = CXGN::BrAPI::v2::Methods->new({

--- a/lib/CXGN/Trait.pm
+++ b/lib/CXGN/Trait.pm
@@ -2,6 +2,7 @@
 package CXGN::Trait;
 
 use Moose;
+use Data::Dumper;
 
 ## to do: add concept of trait short name; provide alternate constructors for term, shortname, and synonyms etc.
 
@@ -10,9 +11,9 @@ has 'bcs_schema' => ( isa => 'Bio::Chado::Schema',
 		  required => 1,
     );
 
-has 'cvterm_id' => (isa => 'Int',
+has 'cvterm_id' => (isa => 'Maybe[Int]',
 		    is => 'rw',
-		    required => 1,
+		    #required => 1,
     );
 
 has 'cvterm' => ( isa => 'Bio::Chado::Schema::Result::Cv::Cvterm', 
@@ -20,7 +21,7 @@ has 'cvterm' => ( isa => 'Bio::Chado::Schema::Result::Cv::Cvterm',
 
 
 has 'name' => ( isa => 'Str',
-		is => 'ro',
+		is => 'rw',
 		lazy => 1,
 		default => sub { 
 		    my $self = shift; 
@@ -109,7 +110,7 @@ has 'db_id'   => (
 );
 
 has 'definition' => (isa => 'Maybe[Str]',
-		     is => 'ro',
+		     is => 'rw',
 		     lazy => 1,
 		     default => sub { 
 			 my $self = shift;
@@ -239,14 +240,175 @@ has 'uri' => (isa => 'Str',
 	}
 );
 
+has 'ontology_id' => (
+	isa => 'Maybe[Int]',
+	is => 'rw',
+);
+
+has 'synonyms' => (
+	isa => 'Maybe[Any]',
+	is  => 'rw'
+);
+
 sub BUILD { 
     #print STDERR "BUILDING...\n";
     my $self = shift;
-    my $cvterm = $self->bcs_schema()->resultset("Cv::Cvterm")->find( { cvterm_id => $self->cvterm_id() });
-    if ($cvterm) { 
-	#print STDERR "Cvterm with ID ".$self->cvterm_id()." was found!\n";
+    my $cvterm;
+
+    if ($self->cvterm_id){
+        $cvterm = $self->bcs_schema()->resultset("Cv::Cvterm")->find( { cvterm_id => $self->cvterm_id });
+        $self->cvterm($cvterm);
     }
-    $self->cvterm($cvterm);
+    if (defined $cvterm) {
+        $self->name($self->name || $cvterm->name );
+		$self->definition($self->definition());
+		$self->ontology_id($self->ontology_id);
+		$self->synonyms($self->synonyms());
+    }
+
+    #my $cvterm = $self->bcs_schema()->resultset("Cv::Cvterm")->find( { cvterm_id => $self->cvterm_id() });
+    #if ($cvterm) {
+	#print STDERR "Cvterm with ID ".$self->cvterm_id()." was found!\n";
+    #}
+    #$self->cvterm($cvterm);
+
+    return $self;
+}
+
+
+sub store {
+    my $self = shift;
+    my $schema = $self->bcs_schema();
+	my $error;
+
+	# new variable
+    my $name = _trim($self->name());
+	my $description = $self->definition();
+	my $ontology_id = $self->ontology_id();
+	my $synonyms = $self->synonyms();
+
+	# get cv_id from sgn_local.conf
+	my $context = SGN::Context->new;
+	my $cv_name = $context->get_conf('trait_ontology_cv_name');
+	my $cvterm_name = $context->get_conf('trait_ontology_cvterm_name');
+
+	# get cv_id for cv_name
+	my $cv = $schema->resultset("Cv::Cv")->find(
+		{
+			name => $cv_name
+		},
+		{ key => 'cv_c1' }
+	);
+	my $cv_id = $cv->get_column('cv_id');
+
+	# get cvterm_id for cvterm_name
+	my $cvterm = $schema->resultset("Cv::Cvterm")->find(
+		{
+			name        => $cvterm_name,
+			cv_id       => $cv_id,
+			is_obsolete => 0
+		},
+		{ key => 'cvterm_c1' }
+	);
+
+	my $root_id = $cvterm->get_column('cvterm_id');
+
+	# check to see if specified ontology exists
+	my $db = $schema->resultset("General::Db")->find($ontology_id);
+
+	if (!defined($db)) {
+		return {error => "Ontology id does not exist"}
+	}
+
+	# check to see if cvterm name already exists and don't attempt if so
+	my $cvterm_exists = $schema->resultset("Cv::Cvterm")->find(
+		{
+			name        => $name,
+			cv_id       => $cv_id,
+			is_obsolete => 0
+		},
+		{ key => 'cvterm_c1' }
+	);
+
+	if (defined($cvterm_exists)) {
+		return {error => "Variable with that name already exists"}
+	}
+
+	# lookup last numeric accession number in ontology if one exists so we can increment off that
+	my $q = "select accession from dbxref where db_id=".$ontology_id." and accession ~ ".q('^\d+$')." order by accession desc limit 1;";
+	my $sth = $self->bcs_schema->storage->dbh->prepare($q);
+	$sth->execute();
+	my ($accession) = $sth->fetchrow_array();
+
+	if (!defined($accession)) {
+		$accession = '0000001';
+	} else {
+		$accession++;
+	}
+
+	# TODO: see if can setup transaction for rollbacks in case of error
+
+	# add trait info to dbxref
+	my $new_term_dbxref = $schema->resultset("General::Dbxref")->create(
+		{   db_id     => $ontology_id,
+			accession => $accession,
+			version   => '1',
+		},
+		{ key => 'dbxref_c1' } ,
+	);
+
+	# add trait info to cvterm
+	my $new_term = $schema->resultset("Cv::Cvterm")->create(
+		{ 	cv_id  => $cv_id,
+			name   => $name,
+			definition => $description,
+			dbxref_id  => $new_term_dbxref->dbxref_id(),
+			is_obsolete => 0
+		});
+
+	# TODO: make sure relationship_type is set correctly
+
+	# set cvtermrelationship VARIABLE_OF to put terms under ontology
+
+	# get cvterm_id for VARIABLE_OF
+	my $variable_of_cvterm = $schema->resultset("Cv::Cvterm")->find(
+		{
+			name        => 'VARIABLE_OF',
+			cv_id       => $cv_id,
+			is_obsolete => 0
+		},
+		{ key => 'cvterm_c1' }
+	);
+
+	my $variable_of_id = $variable_of_cvterm->get_column('cvterm_id');
+
+	# add cvterm_relationship entry linking term to ontology root
+	my $relationship = $schema->resultset("Cv::CvtermRelationship")->create(
+		{ 	type_id  => $variable_of_id,
+			subject_id   => $new_term->get_column('cvterm_id'),
+			object_id => $root_id
+		});
+
+	# add synonyms
+	foreach my $synonym (@{$synonyms}) {
+		$new_term->add_synonym($synonym);
+	}
+
+	return { success => "Variable added successfully\n", id=>undef };
+}
+
+# TODO: common utilities somewhere, used by Location also
+sub _trim { #trim whitespace from both ends of a string
+	my $s = shift;
+	$s =~ s/^\s+|\s+$//g;
+	return $s;
+}
+
+# gmod
+sub numeric_id {
+	my $id = shift;
+	$id =~ s/.*\:(.*)$/$1/g;
+	return $id;
 }
 
 

--- a/lib/CXGN/Trait.pm
+++ b/lib/CXGN/Trait.pm
@@ -406,6 +406,8 @@ sub store {
 
 	my $variable_of_id = $variable_of_cvterm->get_column('cvterm_id');
 
+	my $new_term;
+
 	# setup transaction for rollbacks in case of error
 	my $coderef = sub {
 
@@ -419,7 +421,7 @@ sub store {
 		);
 
 		# add trait info to cvterm
-		my $new_term = $schema->resultset("Cv::Cvterm")->create(
+		$new_term = $schema->resultset("Cv::Cvterm")->create(
 			{ cv_id         => $cv_id,
 				name        => $name,
 				definition  => $description,
@@ -495,8 +497,8 @@ sub store {
 		return {error => "Transaction error trying to write to db"}
 	}
 
-	$self->cvterm_id($variable_of_id);
-	$self->cvterm($cvterm);
+	$self->cvterm_id($new_term->get_column('cvterm_id'));
+	$self->cvterm($new_term);
 
 	return { success => "Variable added successfully\n", variable=>$self };
 }

--- a/lib/CXGN/Trait.pm
+++ b/lib/CXGN/Trait.pm
@@ -442,7 +442,7 @@ sub store {
 			$new_term->add_synonym($synonym);
 		}
 
-		# TODO: save scale properties
+		# save scale properties
 		my $scale = CXGN::BrAPI::v2::Scales->new({
 			bcs_schema => $self->bcs_schema,
 			scale => $self->scale,
@@ -455,7 +455,7 @@ sub store {
 			return {error => $scale->{'error'}};
 		}
 
-		# TODO: save method properties
+		# save method properties
 		my $m = CXGN::BrAPI::v2::Methods->new({
 			bcs_schema => $self->bcs_schema,
 			method => $self->method,

--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -3299,7 +3299,7 @@ sub observationvariable_list_POST {
 
 	my $brapi = $self->brapi_module;
 	my $brapi_module = $brapi->brapi_wrapper('ObservationVariables');
-	my $brapi_package_result = $brapi_module->store(\@all_variables,$user_id);
+	my $brapi_package_result = $brapi_module->store(\@all_variables,$user_id, $c);
 	_standard_response_construction($c, $brapi_package_result);
 }
 

--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -1765,7 +1765,9 @@ sub programs_list : Chained('brapi') PathPart('programs') Args(0) : ActionClass(
 sub programs_list_POST {
 	my $self = shift;
 	my $c = shift;
-	my ($auth,$user_id) = _authenticate_user($c);
+	# TODO: Disabled auth for use with bi-api for now
+	#my ($auth,$user_id) = _authenticate_user($c);
+	my $user_id = undef;
 	my $clean_inputs = $c->stash->{clean_inputs};
 	my $data = $clean_inputs;
 	my @all_programs;
@@ -1824,7 +1826,9 @@ sub programs_detail_GET {
 sub programs_detail_PUT {
 	my $self = shift;
 	my $c = shift;
-	my ($auth,$user_id) = _authenticate_user($c);
+	# TODO: Disabled auth for use with bi-api for now
+	# my ($auth,$user_id) = _authenticate_user($c);
+	my $user_id = undef;
 	my $clean_inputs = $c->stash->{clean_inputs};
 	my $data = $clean_inputs;
 	$data->{programDbId} = $c->stash->{program_id};
@@ -3105,7 +3109,9 @@ sub locations_list : Chained('brapi') PathPart('locations') Args(0) : ActionClas
 sub locations_list_POST {
 	my $self = shift;
 	my $c = shift;
-	my ($auth,$user_id) = _authenticate_user($c);
+	# TODO: disable auth for now with use for bi-api
+	#my ($auth,$user_id) = _authenticate_user($c);
+	my $user_id = undef;
 	my $clean_inputs = $c->stash->{clean_inputs};
 	my $data = $clean_inputs;
 	my @all_locations;
@@ -3147,7 +3153,9 @@ sub locations_detail_PUT {
 	my $self = shift;
 	my $c = shift;
 	my $location_id = shift;
-	my ($auth,$user_id) = _authenticate_user($c);
+	# TODO: disable auth for now with use for bi-api
+	#my ($auth,$user_id) = _authenticate_user($c);
+	my $user_id = undef;
 	my $clean_inputs = $c->stash->{clean_inputs};
 	my $data = $clean_inputs;
 	my @all_locations;
@@ -3288,6 +3296,7 @@ sub observationvariable_list_POST {
 	foreach my $variable (values %{$data}) {
 		push @all_variables, $variable;
 	}
+
 	my $brapi = $self->brapi_module;
 	my $brapi_module = $brapi->brapi_wrapper('ObservationVariables');
 	my $brapi_package_result = $brapi_module->store(\@all_variables,$user_id);

--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -3276,6 +3276,24 @@ sub variables_search_retrieve : Chained('brapi') PathPart('search/variables') Ar
 
 sub observationvariable_list : Chained('brapi') PathPart('variables') Args(0) : ActionClass('REST') { }
 
+sub observationvariable_list_POST {
+	my $self = shift;
+	my $c = shift;
+	# TODO: auth later, not doing for now
+	# my ($auth,$user_id) = _authenticate_user($c);
+	my $user_id;
+	my $clean_inputs = $c->stash->{clean_inputs};
+	my $data = $clean_inputs;
+	my @all_variables;
+	foreach my $variable (values %{$data}) {
+		push @all_variables, $variable;
+	}
+	my $brapi = $self->brapi_module;
+	my $brapi_module = $brapi->brapi_wrapper('ObservationVariables');
+	my $brapi_package_result = $brapi_module->store(\@all_variables,$user_id);
+	_standard_response_construction($c, $brapi_package_result);
+}
+
 sub observationvariable_list_GET {
 	my $self = shift;
 	my $c = shift;


### PR DESCRIPTION
## Changes
- Added db patch to allow saving external references and variable method data
- Added POST /variables
  - Saves all data needed for bi-api integration
- Added POST /variables to /serverinfo
- Pushed breedbase images to dockerhub
  - breedinginsight/breedbase built from https://github.com/Breeding-Insight/sgn
  - breedinginsight/breedbase_pg built from https://github.com/nickmorales/postgres_dockerfile

## Running

```
git clone https://github.com/Breeding-Insight/breedbase_dockerfile.git
cd breedbase_dockerfile
git checkout feature/BI-672
./prepare.sh
./prepare_host.sh
cd repos/sgn
git checkout feature/BI-672
```
Run breedbase development profile (restarts server on changes to code and mounts source):
```
docker-compose up -d breedbase-dev
```

Run patch on db to add new cvterms:
```
docker exec -it breedbase_web bash
cd db/00132
mx-run AddTraitCvterms -H breedbase_db -D empty_fixture -u admin
```

configure sgn_local.conf to have trait ontology variable names tailored to species:
```
trait_ontology_db_name BI_123
trait_ontology_cv_name blueberry_trait
trait_ontology_cvterm_name BI blueberry trait ontology
```
Update onto_root_namespaces in sgn_local.conf to point to correct trait ontology for ontology browser:
```
onto_root_namespaces  BI_123 (Blueberry Trait Ontology), GO (Gene Ontology), PO (Plant Ontology), SO (Sequence Ontology), PATO (Phenotype and Trait Ontology)
```

Add trait ontology variables to db tables:
```
INSERT INTO db (name) VALUES('BI_123');
INSERT INTO cv (name) VALUES('blueberry_trait');
INSERT INTO dbxref(db_id, accession) VALUES((SELECT db_id FROM db WHERE name='BI_123') , '0000000');
INSERT INTO cvterm(cv_id, name, dbxref_id) VALUES(
(SELECT cv_id FROM cv WHERE name='blueberry_trait'),
'BI blueberry trait ontology',
(SELECT dbxref_id FROM dbxref WHERE db_id=(SELECT db_id FROM db WHERE name='BI_123') AND accession='0000000')
);
INSERT INTO dbxref(db_id, accession) VALUES((SELECT db_id FROM db WHERE name='BI_123'), 'VARIABLE_OF');
INSERT INTO cvterm(cv_id, name, dbxref_id, is_relationshiptype) VALUES(
(SELECT cv_id FROM cv WHERE name='blueberry_trait'),
'VARIABLE_OF',
(SELECT dbxref_id FROM dbxref WHERE db_id=(SELECT db_id FROM db WHERE name='BI_123') AND accession='VARIABLE_OF'),
1
);
```

## Limitations
- Ontology id is ignored for POST /variables and ontology specified in sgn_local.conf is always used
  - Doesn't require bi-api to get that information, works as-is
- Bi-api doesn't currently do paging for brapi service request so Breedbase response for GET /variables is set to a large page size so that all varaibles are returned in one response
  - May not play nice with Field Book, should probably add pageSize query parameter in bi-api or otherwise handle paging
 - Does not store/respond with all BrAPI variable data fields, just that needed by bi-api/Field Book
   - Scale just stores min, max, categories, decimal places
   - Method just stores class, description, formula
 - Have not tested Field Book integration, just bi-api. Will need to do that in another card
 - Some preliminary changes to support full integration with /programs & /locations, rest will need to be completed in BI-676
 - Variables should be loaded using POST /variables since ontology scripts do not update all data used by GET /variables