### PR TITLE
BI-674 - Added http status codes for programs and locations

### DIFF
--- a/lib/CXGN/BrAPI/JSONResponse.pm
+++ b/lib/CXGN/BrAPI/JSONResponse.pm
@@ -8,14 +8,16 @@ sub return_error {
     my $self = shift;
     my $status = shift;
     my $message = shift;
-    push @$status, { '400' => $message };
+    my $http_code = shift;
+    push @$status, { 'ERROR' => $message };
     my $formatted_status = _convert_status_obj($status);
     my $pagination = CXGN::BrAPI::Pagination->pagination_response(0,1,0);
     my $response = { 
         'status' => $formatted_status,
         'pagination' => $pagination,
         'result' => undef,
-        'datafiles' => []
+        'datafiles' => [],
+        'http_code' => $http_code
     };
     return $response;
 }

--- a/lib/CXGN/BrAPI/v2/Locations.pm
+++ b/lib/CXGN/BrAPI/v2/Locations.pm
@@ -277,7 +277,7 @@ sub store {
 		my $store = $location->store_location();
 
 		if ($store->{'error'}) {
-			my $err_string = sprintf('Location %s was not stored.',$name);
+			my $err_string = $store->{'error'};
 			warn $err_string;
 			return CXGN::BrAPI::JSONResponse->return_error($self->status, $err_string, 500);
 		} else {

--- a/lib/CXGN/BrAPI/v2/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationVariables.pm
@@ -236,7 +236,6 @@ sub store {
 
     my $self = shift;
     my $data = shift;
-    my $user_id = shift;
     my $c = shift;
 
     my $page_size = $self->page_size;
@@ -294,7 +293,6 @@ sub update {
 
     my $self = shift;
     my $data = shift;
-    my $user_id = shift;
     my $c = shift;
 
     my $schema = $self->bcs_schema();

--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -234,6 +234,9 @@ sub _standard_response_construction {
 	my $result = $brapi_package_result->{result};
 	my $datafiles = $brapi_package_result->{datafiles};
 
+	# some older brapi stuff uses parameter, could refactor at some point
+	if (!$return_status) { $return_status = $brapi_package_result->{http_code} };
+
 	my %metadata = (pagination=>$pagination, status=>$status, datafiles=>$datafiles);
 	my %response = (metadata=>\%metadata, result=>$result);
 	$c->stash->{rest} = \%response;
@@ -1765,9 +1768,7 @@ sub programs_list : Chained('brapi') PathPart('programs') Args(0) : ActionClass(
 sub programs_list_POST {
 	my $self = shift;
 	my $c = shift;
-	# TODO: Disabled auth for use with bi-api for now
-	#my ($auth,$user_id) = _authenticate_user($c);
-	my $user_id = undef;
+	my ($auth,$user_id) = _authenticate_user($c);
 	my $clean_inputs = $c->stash->{clean_inputs};
 	my $data = $clean_inputs;
 	my @all_programs;
@@ -1776,7 +1777,8 @@ sub programs_list_POST {
 	}
 	my $brapi = $self->brapi_module;
 	my $brapi_module = $brapi->brapi_wrapper('Programs');
-	my $brapi_package_result = $brapi_module->store(\@all_programs,$user_id);
+
+	my $brapi_package_result = $brapi_module->store(\@all_programs, $user_id);
 	_standard_response_construction($c, $brapi_package_result);
 }
 
@@ -1826,8 +1828,7 @@ sub programs_detail_GET {
 sub programs_detail_PUT {
 	my $self = shift;
 	my $c = shift;
-	# TODO: Disabled auth for use with bi-api for now
-	# my ($auth,$user_id) = _authenticate_user($c);
+	my ($auth,$user_id) = _authenticate_user($c);
 	my $user_id = undef;
 	my $clean_inputs = $c->stash->{clean_inputs};
 	my $data = $clean_inputs;
@@ -3138,8 +3139,7 @@ sub locations_list : Chained('brapi') PathPart('locations') Args(0) : ActionClas
 sub locations_list_POST {
 	my $self = shift;
 	my $c = shift;
-	# TODO: disable auth for now with use for bi-api
-	#my ($auth,$user_id) = _authenticate_user($c);
+	my ($auth,$user_id) = _authenticate_user($c);
 	my $user_id = undef;
 	my $clean_inputs = $c->stash->{clean_inputs};
 	my $data = $clean_inputs;
@@ -3182,8 +3182,7 @@ sub locations_detail_PUT {
 	my $self = shift;
 	my $c = shift;
 	my $location_id = shift;
-	# TODO: disable auth for now with use for bi-api
-	#my ($auth,$user_id) = _authenticate_user($c);
+	my ($auth,$user_id) = _authenticate_user($c);
 	my $user_id = undef;
 	my $clean_inputs = $c->stash->{clean_inputs};
 	my $data = $clean_inputs;


### PR DESCRIPTION
## Changes
- Added HTTP status codes to POST/PUT programs & locations
  - Updated existing `JSONResponse->return_error` rather than using exceptions (talked with Chris about this)
  - Can't use exceptions in CXGN objects without handling in other callers which would take more work
- Took out some extraneous auth stuff handled by serverinfo