### PR TITLE
[BI-989] - Wrap POST variables in a transaction

### DIFF
--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -3367,10 +3367,17 @@ sub observationvariable_list_POST {
 	my $c = shift;
 	my ($auth,$user_id) = _authenticate_user($c);
 
+	my $clean_inputs = $c->stash->{clean_inputs};
+	my $data = $clean_inputs;
+	_validate_request($c, 'ARRAY', $data, [
+		'observationVariableName',
+		{'scale' => ['dataType', 'scaleName']},
+		{'method' => ['methodName', 'methodClass', 'description']},
+		{'trait' => ['traitName', 'status']}
+	]);
+
 	my $response;
 	try {
-		my $clean_inputs = $c->stash->{clean_inputs};
-		my $data = $clean_inputs;
 		my @all_variables;
 		foreach my $variable (values %{$data}) {
 			push @all_variables, $variable;


### PR DESCRIPTION
- Wraps POST variables code in a transaction, so if there is a failure, none of the traits are saved. 
- Added required field checks to POST variables endpoint. 