### PR TITLE
[BI-998] - Add brapi variables additional info

### DIFF
--- a/db/00145/AddCvtermAdditionalInfo.pm
+++ b/db/00145/AddCvtermAdditionalInfo.pm
@@ -1,0 +1,85 @@
+#!/usr/bin/env perl
+
+
+=head1 NAME
+
+ AddCvtermAdditionalInfo
+
+=head1 SYNOPSIS
+
+mx-run ThisPackageName [options] -H hostname -D dbname -u username [-F]
+
+this is a subclass of L<CXGN::Metadata::Dbpatch>
+see the perldoc of parent class for more details.
+
+=head1 DESCRIPTION
+
+This patch adds a system cvterm that is used to store additional info for cvterms.
+
+This subclass uses L<Moose>. The parent class uses L<MooseX::Runnable>
+
+=head1 AUTHOR
+
+ Chris Tucker<ct447@cornell.edu>
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2010 Boyce Thompson Institute for Plant Research
+
+This program is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut
+
+
+package AddCvtermAdditionalInfo;
+
+use Moose;
+use Try::Tiny;
+use Bio::Chado::Schema;
+
+extends 'CXGN::Metadata::Dbpatch';
+
+
+has '+description' => ( default => <<'' );
+This patch adds a system cvterm that is used to store additional info for cvterms.
+
+has '+prereq' => (
+    default => sub {
+        [],
+    },
+);
+
+sub patch {
+    my $self=shift;
+
+    print STDOUT "Executing the patch:\n " .   $self->name . ".\n\nDescription:\n  ".  $self->description . ".\n\nExecuted by:\n " .  $self->username . " .";
+    print STDOUT "\nChecking if this db_patch was executed before or if previous db_patches have been executed.\n";
+    print STDOUT "\nExecuting the SQL commands.\n";
+
+    my $schema = Bio::Chado::Schema->connect( sub { $self->dbh->clone } );
+
+    my $coderef = sub {
+
+        my $new_stock_cvterm = $schema->resultset("Cv::Cvterm")->create_with(
+            {
+                name => 'cvterm_additional_info',
+                definition => 'BrAPI Additional Info field',
+                cv   => 'trait_property',
+            }
+        );
+    };
+
+    try {
+        $schema->txn_do($coderef);
+
+    } catch {
+        die "Load failed! " . $_ .  "\n" ;
+    };
+
+    print "You're done!\n";
+}
+
+####
+1; #
+####

--- a/lib/CXGN/BrAPI/v2/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationVariables.pm
@@ -249,7 +249,7 @@ sub get_query {
         "LEFT JOIN cvtermsynonym using(cvterm_id) ". # left join to include non-synoynm variables, may break field book due to bug
         "JOIN cvterm_relationship as rel on (rel.subject_id=cvterm.cvterm_id) ".
         "JOIN cvterm as reltype on (rel.type_id=reltype.cvterm_id) $join ".
-        "JOIN cvtermprop as additional_info on (cvterm.cvterm_id = additional_info.cvterm_id and additional_info.type_id = $additional_info_type_id) ".
+        "LEFT JOIN cvtermprop as additional_info on (cvterm.cvterm_id = additional_info.cvterm_id and additional_info.type_id = $additional_info_type_id) ".
         "WHERE $and_where " .
         "GROUP BY cvterm.cvterm_id, db.name, db.db_id, dbxref.dbxref_id, dbxref.accession, additional_info.value ".
         "ORDER BY cvterm.name ASC LIMIT $limit OFFSET $offset; "  ;


### PR DESCRIPTION
This is to facilitate adding tags to traits via the additional info field. I'll wait to merge this until the work on bi-api and bi-web is done.

Something like this:

```
{
  "observationVariableName": "yada yada",
  "additionalInfo": {
    "tags": ["favorites", "sea lice", "smolt"]
  }
}
```

See other PRs for this feature:
brapi: https://github.com/Breeding-Insight/brapi/pull/40
bi-api: https://github.com/Breeding-Insight/bi-api/pull/95
bi-web: https://github.com/Breeding-Insight/bi-web/pull/99

Tested out:

POST variables with and without additionalInfo.
PUT variables with additional info (overwrites existing), and without (deletes additional info)
GET variables and POST search/variables both return additionalInfo
