### PR TITLE
[BI-763] BreedBase fixes to support Field Book v5.0 w/ BrAPI v2

### DIFF
--- a/lib/CXGN/BrAPI/v2/Images.pm
+++ b/lib/CXGN/BrAPI/v2/Images.pm
@@ -125,7 +125,7 @@ sub search {
                 additionalInfo => {
                     observationLevel => $_->{'stock_type_name'},
                     observationUnitName => $_->{'stock_uniquename'},
-                    tags =>  $_->{'tags_array'},
+                    #tags =>  $_->{'tags_array'},
                 },
                 copyright => $_->{'image_username'} . " " . substr($_->{'image_modified_date'},0,4),
                 description => $_->{'image_description'},
@@ -142,13 +142,13 @@ sub search {
                 mimeType => _get_mimetype($_->{'image_file_ext'}),
                 observationUnitDbId => qq|$_->{'stock_id'}|,
                 # location and linked phenotypes are not yet available for images in the db
-                imageLocation => {
-                    geometry => {
-                        coordinates => [],
-                        type=> '',
-                    },
-                    type => '',
-                },
+                #imageLocation => {
+                #    geometry => {
+                #        coordinates => [],
+                #        type=> '',
+                #    },
+                #    type => '',
+                #},
                 observationDbIds => [@observationDbIds],
             };
         }
@@ -211,7 +211,7 @@ sub detail {
             additionalInfo => {
                 observationLevel => $_->{'stock_type_name'},
                 observationUnitName => $_->{'stock_uniquename'},
-                tags =>  $_->{'tags_array'},
+                #tags =>  $_->{'tags_array'},
             },
             copyright => $_->{'image_username'} . " " . substr($_->{'image_modified_date'},0,4),
             description => $_->{'image_description'},
@@ -228,13 +228,13 @@ sub detail {
             mimeType => _get_mimetype($_->{'image_file_ext'}),
             observationUnitDbId => qq|$_->{'stock_id'}|,
             # location and linked phenotypes are not yet available for images in the db
-            imageLocation => {
-                geometry => {
-                    coordinates => [],
-                    type=> '',
-                },
-                type => '',
-            },
+            #imageLocation => {
+            #    geometry => {
+            #        coordinates => [],
+            #        type=> '',
+            #    },
+            #    type => '',
+            #},
             observationDbIds => [@observationDbIds],
         );
     }
@@ -428,7 +428,7 @@ sub image_metadata_store {
             additionalInfo => {
                 observationLevel => $_->{'stock_type_name'},
                 observationUnitName => $_->{'stock_uniquename'},
-                tags =>  $_->{'tags_array'},
+                #tags =>  $_->{'tags_array'},
             },
             copyright => $_->{'image_username'} . " " . substr($_->{'image_modified_date'},0,4),
             description => $_->{'image_description'},
@@ -445,13 +445,13 @@ sub image_metadata_store {
             mimeType => _get_mimetype($_->{'image_file_ext'}),
             observationUnitDbId => qq|$_->{'stock_id'}|,
             # location and linked phenotypes are not yet available for images in the db
-            imageLocation => {
-                geometry => {
-                    coordinates => [],
-                    type=> '',
-                },
-                type => '',
-            },
+            #imageLocation => {
+            #    geometry => {
+            #        coordinates => [],
+            #        type=> '',
+            #    },
+            #    type => '',
+            #},
             observationDbIds => [@observationDbIds],
         };
 
@@ -548,13 +548,13 @@ sub image_data_store {
          mimeType => _get_mimetype($_->{'image_file_ext'}),
          observationUnitDbId => $_->{'stock_id'},
          # location and linked phenotypes are not yet available for images in the db
-         imageLocation => {
-             geometry => {
-                 coordinates => [],
-                 type=> '',
-             },
-             type => '',
-         },
+         #imageLocation => {
+         #    geometry => {
+         #        coordinates => [],
+         #        type=> '',
+         #    },
+         #    type => '',
+         #},
          observationDbIds => [@observationDbIds],
      );
     }

--- a/lib/CXGN/BrAPI/v2/Images.pm
+++ b/lib/CXGN/BrAPI/v2/Images.pm
@@ -458,9 +458,15 @@ sub image_metadata_store {
         $counter++;
     }
 
-    my %result = (data => \@data);
+    my $result;
+    if ($image_id) {
+        $result = $data[0];
+    } else {
+        $result = {data => \@data};
+    }
+
     my $pagination = CXGN::BrAPI::Pagination->pagination_response($counter,$page_size,$page);
-    return CXGN::BrAPI::JSONResponse->return_success( \%result, $pagination, undef, $self->status(), 'Image metadata stored');
+    return CXGN::BrAPI::JSONResponse->return_success( $result, $pagination, undef, $self->status(), 'Image metadata stored');
 }
 
 sub image_data_store {

--- a/lib/CXGN/BrAPI/v2/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationVariables.pm
@@ -187,11 +187,12 @@ sub search {
         }
 
         $trait_ids_sql =~ s/^,//g;
-
         if ($trait_ids_sql){
             push @and_wheres, "cvterm.cvterm_id IN ($trait_ids_sql)";
         } else {
-            return CXGN::BrAPI::JSONResponse->return_error($self->status, sprintf('Variables not found for the searched studyDbId'), 400);
+            my @data_files;
+            my $pagination = CXGN::BrAPI::Pagination->pagination_response(0,$page_size,$page);
+            return CXGN::BrAPI::JSONResponse->return_success({data => []}, $pagination, \@data_files, $status, 'Observationvariable search result constructed');
         }
     }
 

--- a/lib/CXGN/BrAPI/v2/Scales.pm
+++ b/lib/CXGN/BrAPI/v2/Scales.pm
@@ -272,7 +272,7 @@ sub store {
                 {
                     cvterm_id => $cvterm_id,
                     type_id   => $scale_categories_label_id,
-                    value     => $label || $label_counter,
+                    value     => defined $label ? $label : $label_counter,
                     rank      => $rank
                 }
             );

--- a/lib/CXGN/Phenotypes/StorePhenotypes.pm
+++ b/lib/CXGN/Phenotypes/StorePhenotypes.pm
@@ -565,14 +565,8 @@ sub store {
                             $new_count++;
                         }
                         $check_unique_trait_stock{$trait_cvterm->cvterm_id(), $stock_id} = 1;
-                    }
-                    if ($ignore_new_values) {
-                        if (exists($check_unique_trait_stock{$trait_cvterm->cvterm_id(), $stock_id})) {
-                            $skip_count++;
-                            next;
-                        } else {
-                            $new_count++;
-                        }
+                    } else {
+                        $new_count++;
                     }
 
                     my $phenotype;

--- a/lib/CXGN/Phenotypes/StorePhenotypes.pm
+++ b/lib/CXGN/Phenotypes/StorePhenotypes.pm
@@ -565,7 +565,8 @@ sub store {
                             $new_count++;
                         }
                         $check_unique_trait_stock{$trait_cvterm->cvterm_id(), $stock_id} = 1;
-                    } else {
+                    }
+                    if ($ignore_new_values) {
                         if (exists($check_unique_trait_stock{$trait_cvterm->cvterm_id(), $stock_id})) {
                             $skip_count++;
                             next;

--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -4334,7 +4334,7 @@ sub images_single_PUT {
 
 	# Check user auth. This matches observations PUT observations endpoint authorization.
 	# No specific roles are check, just that the user has an account.
-	my $force_authenticate = 1;
+	my $force_authenticate = 0;
 	my ($auth_success, $user_id, $user_type, $user_pref, $expired) = _authenticate_user($c, $force_authenticate);
 
     my $clean_inputs = $c->stash->{clean_inputs};

--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -275,6 +275,7 @@ sub _authenticate_user {
 	# Will still throw error if auth is required
 	if ($c->config->{brapi_default_user} && $c->config->{brapi_require_login} == 0) {
 		$user_id = CXGN::People::Person->get_person_by_username($c->dbc->dbh, $c->config->{brapi_default_user});
+		$user_type = 'curator';
 		if (! defined $user_id) {
 			my $brapi_package_result = CXGN::BrAPI::JSONResponse->return_error($status, 'Default brapi user was not found');
 			_standard_response_construction($c, $brapi_package_result, 500);

--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -2621,7 +2621,7 @@ sub observation_units_POST {
 	my $self = shift;
 	my $c = shift;
 	# The observation units need an operator, so login required
-	my $force_authenticate = 1;
+	my $force_authenticate = 0;
 	my ($auth,$user_id) = _authenticate_user($c, $force_authenticate);
 	my $clean_inputs = $c->stash->{clean_inputs};
 	my $data = $clean_inputs;

--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -4288,7 +4288,7 @@ sub images_POST {
 
 	# Check user auth. This matches observations PUT observations endpoint authorization.
 	# No specific roles are check, just that the user has an account.
-	my $force_authenticate = 1;
+	my $force_authenticate = 0;
 	my ($auth_success, $user_id, $user_type, $user_pref, $expired) = _authenticate_user($c, $force_authenticate);
 
     my $clean_inputs = $c->stash->{clean_inputs};

--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -3799,7 +3799,7 @@ sub observations_PUT {
 	my $version = $c->request->captures->[0];
 	my $brapi_package_result;
 	if ($version eq 'v2'){
-		my $force_authenticate = 1;
+		my $force_authenticate = 0;
 		my ($auth,$user_id,$user_type) = _authenticate_user($c,$force_authenticate);
 	    my $clean_inputs = $c->stash->{clean_inputs};
 	    my %observations = %$clean_inputs;
@@ -3958,7 +3958,7 @@ sub save_observation_results {
     my $version = shift;
 
 	# Check that the user is a user. We don't check other permissions for now.
-	my $force_authenticate = 1;
+	my $force_authenticate = 0;
 	my ($auth_success, $user_id, $user_type, $user_pref, $expired) = _authenticate_user($c, $force_authenticate);
 
 	my $dbh = $c->dbc->dbh;


### PR DESCRIPTION
- Image response needed to be formatted so the brapi client library could parse the response
  - BrAPI Client only allows string values in additional info
  - The imageLocation was an improper geojson, so I removed it since it wasn't being populated. 
- Fixed BreedBase bug to allow repeat observations with different time stamps
  - https://github.com/solgenomics/sgn/issues/3630#issuecomment-885000676
- Removed 400 return if no variables were found for call `GET /variables?studyDbId={studyDbId}`
- Add `curator` role to default brapi user, and removed a bunch of forced authentication calls. 
- Fix error with POST /variables where the scale category labels were both being set to 1. 

**Testing**
1. Tested directly against BreedBase from Field Book
2. Test via the bi-api proxy from Field Book
  - Testing process:
    - Authenticate to bi-api with the "Original Field Book Auth"
    - Change brapi version to v2
    - Import studies
      - Check filter by trial and filter by program to make sure everything works as expected there
    - Select a study and save
    - Go to traits and confirm traits were brought in with study (if applicable at this point)
    - Import brapi traits and import a couple more
      - Select a couple of categorical traits
      - Ideally, you'll have at least one text, numerical, categorical trait
    - Change one of the traits to photo
    - Collect data on a few of your fields for each trait
    - Export data to brapi
    - Check BreedBase for your observations and images to confirm they were saved
      - For images, try entering the image path in your browser to see the image. You might need to add the port :7080 onto localhost.
    - Go back to the collection
    - Edit a few traits
    - Export and confirm 