### PR TITLE
[BI-1039] Switch label/value for brapi v1 category

### DIFF
--- a/lib/CXGN/BrAPI/v2/Scales.pm
+++ b/lib/CXGN/BrAPI/v2/Scales.pm
@@ -290,7 +290,8 @@ sub store {
             $rank++;
 
             # form categories string for v1 call
-            $categories_v1=$categories_v1.$label."=".$value."/";
+            # For brapi v1, label = meaning, in brapi v2 terms, value = label.
+            $categories_v1=$categories_v1.$value."=".$label."/";
         }
 
         my $format = $schema->resultset("Cv::Cvtermprop")->create(

--- a/lib/CXGN/BrAPI/v2/Scales.pm
+++ b/lib/CXGN/BrAPI/v2/Scales.pm
@@ -262,7 +262,6 @@ sub store {
     my $coderef = sub {
 
         # write category values for v2
-        my $label_counter = 1;
         foreach my $category (@scale_categories) {
             my $label = $category->{'label'};
             my $value = $category->{'value'};
@@ -272,11 +271,10 @@ sub store {
                 {
                     cvterm_id => $cvterm_id,
                     type_id   => $scale_categories_label_id,
-                    value     => defined $label ? $label : $label_counter,
+                    value     => defined $label && $label ne "" ? $label : $value,
                     rank      => $rank
                 }
             );
-            $label_counter += 1;
 
             my $prop_source = $schema->resultset("Cv::Cvtermprop")->create(
                 {


### PR DESCRIPTION
We switched up label and value for our brapi labels, in order for brapi v1 to keep working properly with FieldBook and our fixed trait importer, needed to switch brapi v1 categories to be `value=label` to match the v1 standard of `label=meaning`.