### PR TITLE
[BI-1057] Fix plot sorting for Field Book in brapi v1 & v2 endpoints

### DIFF
--- a/lib/CXGN/BrAPI/v1/ObservationUnits.pm
+++ b/lib/CXGN/BrAPI/v1/ObservationUnits.pm
@@ -62,6 +62,8 @@ sub search {
             observation_unit_names_list=>$observation_unit_names_list,
             limit=>$limit,
             offset=>$offset,
+            # Order by plot_number, account for non-numeric plot numbers
+            order_by=>'NULLIF(regexp_replace(plot_number, \'\D\', \'\', \'g\'), \'\')::int',
             # phenotype_min_value=>$phenotype_min_value,
             # phenotype_max_value=>$phenotype_max_value,
             # exclude_phenotype_outlier=>$exclude_phenotype_outlier

--- a/lib/CXGN/BrAPI/v1/Studies.pm
+++ b/lib/CXGN/BrAPI/v1/Studies.pm
@@ -659,7 +659,8 @@ sub observation_units {
             include_timestamp=>1,
             limit=>$limit,
             offset=>$offset,
-            order_by=>"plot_number"
+			# Order by plot_number, account for non-numeric plot numbers
+			order_by=>'NULLIF(regexp_replace(plot_number, \'\D\', \'\', \'g\'), \'\')::int',
         }
     );
     my ($data, $unique_traits) = $phenotypes_search->search();

--- a/lib/CXGN/BrAPI/v2/ObservationUnits.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationUnits.pm
@@ -87,6 +87,8 @@ sub search {
             plot_list=>$observation_unit_db_id,
             limit=>$limit,
             offset=>$offset,
+            # Order by plot_number, account for non-numeric plot numbers
+            order_by=>'NULLIF(regexp_replace(plot_number, \'\D\', \'\', \'g\'), \'\')::int',
             observation_unit_names_list=>$observation_unit_names_list,
             # phenotype_min_value=>$phenotype_min_value,
             # phenotype_max_value=>$phenotype_max_value,


### PR DESCRIPTION
Adds a fix for plot sorting by plot number in the brapi v1 & v2 endpoints. 

Accounts for the following cases:
1. Plot number is NULL, works fine, gets put last
2. Plot number is an empty string, gets converted to NULL
3. Plot number is a string with all letters, gets converted to NULL
4. Plot number is a string with letters and numbers, letters get removed and numbers remain
5. Plot number is all numbers, all numbers remain. 

Fixes: https://github.com/Breeding-Insight/sgn/issues/25