### PR TITLE
Docker image updates for develop and master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,11 @@ jobs:
         working-directory: ./breedbase_dockerfile
         run: git submodule update --init --recursive --remote
 
+      - name: Extract branch name
+        shell: bash
+        run: echo ::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})
+        id: extract_branch
+
       - name: Set tag
         id: vars
         run: echo ::set-output name=imageName::$(echo breedinginsight/breedbase:${{ steps.get-latest-tag.outputs.tag }}-$GITHUB_RUN_NUMBER)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,9 @@ name: breedbase build
 on:
   push:
     branches:
+      - develop
       - master
+  workflow_dispatch:
 
 jobs:
   build:
@@ -50,9 +52,24 @@ jobs:
         working-directory: ./breedbase_dockerfile
         run: git submodule update --init --recursive --remote
 
+      - name: Set tag
+        id: vars
+        run: echo ::set-output name=imageName::$(breedinginsight/breedbase:${{ steps.get-latest-tag.outputs.tag }}-$GITHUB_RUN_NUMBER)
+        
       - name: Build Docker and push image
         working-directory: ./breedbase_dockerfile
         run: |
-          docker build . --file Dockerfile --tag breedinginsight/breedbase:${{ steps.get-latest-tag.outputs.tag }}-$GITHUB_RUN_NUMBER --tag breedinginsight/breedbase:latest
-          docker push breedinginsight/breedbase:${{ steps.get-latest-tag.outputs.tag }}-$GITHUB_RUN_NUMBER
+          docker build . --file Dockerfile --tag ${{steps.vars.outputs.imageName}}
+          docker push ${{steps.vars.outputs.imageName}}
+          
+      - name: Tag develop
+        if: steps.extract_branch.outputs.branch == 'develop'
+        run: |
+          docker tag ${{steps.vars.outputs.imageName}} breedinginsight/breedbase:develop
+          docker push breedinginsight/breedbase:develop
+          
+      - name: Tag master
+        if: steps.extract_branch.outputs.branch == 'master'
+        run: |
+          docker tag ${{steps.vars.outputs.imageName}} breedinginsight/breedbase:latest
           docker push breedinginsight/breedbase:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Set tag
         id: vars
-        run: echo ::set-output name=imageName::$(breedinginsight/breedbase:${{ steps.get-latest-tag.outputs.tag }}-$GITHUB_RUN_NUMBER)
+        run: echo ::set-output name=imageName::$(echo breedinginsight/breedbase:${{ steps.get-latest-tag.outputs.tag }}-$GITHUB_RUN_NUMBER)
         
       - name: Build Docker and push image
         working-directory: ./breedbase_dockerfile


### PR DESCRIPTION
Will create a tagged version regardless of branch like:

sgn-304.1-57

Then will update develop tag for develop branch pushes and latest tag for master branch pushes. This matches the scheme from biapi and is a little different for your conversation with Lynn but she can just grab the specific version tag when we push a new image if she wants.