### PR TITLE
[BI-1229] Fix matview refreshing check

### DIFF
--- a/lib/CXGN/BrAPI/v2/ObservationUnits.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationUnits.pm
@@ -714,12 +714,12 @@ sub _refresh_matviews {
     # Refresh materialized view so data can be retrieved
     my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'phenotypes', 'concurrent', $c->config->{basepath});
     # Wait until materialized view is reset. Wait 5 minutes total, then throw an error
-    my $refreshing = 0;
+    my $refreshing = 1;
     my $refresh_time = 0;
     while ($refreshing && $refresh_time < $timeout) {
         my $refresh_status = $bs->matviews_status();
-        if ($refresh_status->{timestamp}) {
-            $refreshing = 1;
+        if (!$refresh->{connection}->alive) {
+            $refreshing = 0;
         } elsif ($refresh_time >= $timeout) {
             return {error => CXGN::BrAPI::JSONResponse->return_error($self->status, "Refreshing materialized views is taking too long to return a response", 500)};
         } else {

--- a/lib/CXGN/BreederSearch.pm
+++ b/lib/CXGN/BreederSearch.pm
@@ -367,9 +367,9 @@ sub refresh_matviews {
             }
 
             if ($refresh_finished) {
-                return { message => $materialized_view.' update completed!' };
+                return { message => $materialized_view . ' update completed!', connection => $async_refresh };
             } else {
-                return { message => $materialized_view.' update initiated.' };
+                return { message => $materialized_view.' update initiated.', connection => $async_refresh  };
             }
         } catch {
             print STDERR 'Error initiating '.$materialized_view.' update.' . $@ . "\n";


### PR DESCRIPTION
Checking the matview status in the table was not an accurate way to check that the phenotype_jsonb materialized view was done refreshing. 