### PR TITLE
[BI-1251] Fix BreedBase germplasm search

### DIFF
--- a/db/00144/FixFieldbookImageCvterm.pm
+++ b/db/00144/FixFieldbookImageCvterm.pm
@@ -48,7 +48,6 @@ has '+prereq' => (
         [],
     },
 
-);
 
 sub patch {
     my $self=shift;

--- a/db/run_all_patches.pl
+++ b/db/run_all_patches.pl
@@ -33,13 +33,13 @@ my $startfrom = 0;
 my $test;
 
 GetOptions(
-    "user=s" => \$dbuser,
-    "pass=s" => \$dbpass,
-    "host=s" => \$host,
-    "db=s" => \$db,
+    "user=s"        => \$dbuser,
+    "pass=s"        => \$dbpass,
+    "host=s"        => \$host,
+    "db=s"          => \$db,
     "editinguser=s" => \$editinguser,
-    "startfrom:i" => \$startfrom,
-    "test" => \$test
+    "startfrom:i"   => \$startfrom,
+    "test"          => \$test
 );
 
 my $db_patch_path = dirname(abs_path($0));
@@ -47,27 +47,32 @@ chdir($db_patch_path);
 
 my @folders = grep /[0-9]{5}/, (split "\n", `ls -d */`);
 my $cmd = "echo -ne \"$dbpass\n\" | psql -h $host -U $dbuser -t -c \"select patch_name from Metadata.md_dbversion\" -d $db";
-my @installed = grep { !/^$/ } map { s/^\s+|\s+$//gr } `$cmd`;
+my @installed = grep {!/^$/} map {s/^\s+|\s+$//gr} `$cmd`;
 
 for (my $i = 0; $i < (scalar @folders); $i++) {
-    if (($folders[$i]=~s/\/$//r)>=$startfrom){
+    if (($folders[$i] =~ s/\/$//r) >= $startfrom) {
         chdir($db_patch_path);
         chdir($folders[$i]);
-        my @patches = grep {!($_ ~~ @installed)} map { s/.pm//r } (split "\n", `ls`);
+        my @patches = grep {!($_ ~~ @installed)} map {s/.pm//r} (split "\n", `ls`);
         for (my $j = 0; $j < (scalar @patches); $j++) {
             my $patch = $patches[$j];
-	    
-	    if ($patch =~ /\~$/) { 
-		print STDERR "Ignoring $patch...\n";
-		next;
-	    }
 
+            if ($patch =~ /\~$/) {
+                print STDERR "Ignoring $patch...\n";
+                next;
+            }
 
+            my $cmd = "echo -ne \"$dbuser\\n$dbpass\" | mx-run $patch -H $host -D $db -u $editinguser" . ($test ? ' -t' : '');
+            print STDERR $cmd . "\n";
+            my $returnCode = system("bash -c '$cmd'");
 
-            my $cmd = "echo -ne \"$dbuser\\n$dbpass\" | mx-run $patch -H $host -D $db -u $editinguser".($test?' -t':'');
-            print STDERR $cmd."\n";
-            system("bash -c '$cmd'");
+            if ($returnCode != 0 && $returnCode != 1) {
+                die "Failed executing patch: $patch";
+            }
+
             print STDERR "\n\n\n";
         }
     }
 }
+
+print STDERR "DB patching complete, database is up to date\n";

--- a/lib/CXGN/BrAPI/v2/Germplasm.pm
+++ b/lib/CXGN/BrAPI/v2/Germplasm.pm
@@ -64,12 +64,10 @@ sub search {
 
     my %stockprops_values;
     if ($accession_numbers_arrayref && scalar(@$accession_numbers_arrayref)>0){
-        foreach (@$accession_numbers_arrayref) {
-            $stockprops_values{'accession number'} = {
-                matchtype => 'contains',
-                value => $_
-            };
-        }
+        $stockprops_values{'accession number'} = {
+            matchtype => 'one of',
+            value => join(',', @$accession_numbers_arrayref)
+        };
     }
     if ($germplasm_puis_arrayref && scalar(@$germplasm_puis_arrayref)>0){
         foreach (@$germplasm_puis_arrayref) {

--- a/lib/CXGN/Stock/Search.pm
+++ b/lib/CXGN/Stock/Search.pm
@@ -462,7 +462,13 @@ sub search {
                 if ( $matchtype eq 'one of' ) {
                     my @values = split ',', $value;
                     my $search_vals_sql = "'".join ("','" , @values)."'";
-                    push @stockprop_wheres, "\"".$term_name."\"::text \\?| array[$search_vals_sql]";
+                    my $stockprop_list_search_sql = "stock_id in " .
+                        "(" .
+                            "select id from (" .
+	                            "select jsonb_object_keys(\"$term_name\") as accession_number_key, stock_id as id from materialized_stockprop" .
+                            ") as json_return where json_return.accession_number_key in ($search_vals_sql)" .
+                        ")";
+                    push @stockprop_wheres, $stockprop_list_search_sql;
                 } else {
                     push @stockprop_wheres, "\"".$term_name."\"::text ilike $search";
                 }


### PR DESCRIPTION
# Description

Based on BI-1204, so will have some changes from that. 

Fixes the accession number search in BreedBase to:
1. Accept a list of accession numbers
2. Do an exact match instead of `contains`

# Dependencies
biapi BI-1251
biweb develop

# Testing
1. Upload this file via the germplasm import to test parent references in the same file. 
[BI-1251_file_parents.xls](https://github.com/Breeding-Insight/sgn/files/7707197/BI-1251_file_parents.xls)
2. With insomnia do `GET germplasm` to check the new germplasm objects for proper data.
3. Upload this file to test parent dbId referencing
[BI-1251_db_parents.xls](https://github.com/Breeding-Insight/sgn/files/7707199/BI-1251_db_parents.xls)
4. With insomnia do `GET germplasm` to check the new germplasm objects for proper data and parental connections. 
5. Try out your own file to try and break it