### PR TITLE
[BI-1245] Fix variables pagination

### DIFF
--- a/lib/CXGN/BrAPI/v2/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationVariables.pm
@@ -12,7 +12,6 @@ use CXGN::BrAPI::v2::ExternalReferences;
 use CXGN::BrAPI::v2::Methods;
 use CXGN::BrAPI::v2::Scales;
 use CXGN::BrAPI::Exceptions::NotFoundException;
-use POSIX;
 
 extends 'CXGN::BrAPI::v2::Common';
 

--- a/lib/CXGN/BrAPI/v2/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationVariables.pm
@@ -12,6 +12,7 @@ use CXGN::BrAPI::v2::ExternalReferences;
 use CXGN::BrAPI::v2::Methods;
 use CXGN::BrAPI::v2::Scales;
 use CXGN::BrAPI::Exceptions::NotFoundException;
+use POSIX;
 
 extends 'CXGN::BrAPI::v2::Common';
 
@@ -295,9 +296,8 @@ sub get_query {
     my @data_files;
 
     if ($array) {
-        my $data_window;
-        ($data_window, $pagination) = CXGN::BrAPI::Pagination->paginate_array(\@variables, $page_size, $page);
-        %result = (data => $data_window);
+        %result = (data => \@variables);
+        $pagination = CXGN::BrAPI::Pagination->pagination_response($total_count,$page_size,$page);
         return CXGN::BrAPI::JSONResponse->return_success(\%result, $pagination, \@data_files, $status, 'Observationvariable search result constructed');
     } else {
         $pagination = CXGN::BrAPI::Pagination->pagination_response($total_count,$page_size,$page);


### PR DESCRIPTION
To test: 

- Have some variables loaded into your system. 
- Try various page sizes and pages on the `GET /variables` endpoint
- Check to make sure the pagination is correct and the number of returned variables is correct. 