### PR TITLE
[BI-1164] Refresh materialized view after trial and OU save

### DIFF
--- a/lib/SGN/Controller/AJAX/Trial.pm
+++ b/lib/SGN/Controller/AJAX/Trial.pm
@@ -1196,7 +1196,6 @@ sub upload_multiple_trial_designs_file_POST : Args(0) {
             $chado_schema->txn_rollback();
             push @{$save{'errors'}}, $current_save->{'error'};
         }
-
       }
 
     };
@@ -1217,8 +1216,8 @@ sub upload_multiple_trial_designs_file_POST : Args(0) {
     } else {
         my $dbh = $c->dbc->dbh();
         my $bs = CXGN::BreederSearch->new( { dbh=>$dbh, dbname=>$c->config->{dbname}, } );
-        my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'stockprop', 'concurrent', $c->config->{basepath});
-
+        $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'stockprop', 'concurrent', $c->config->{basepath});
+        $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'phenotypes', 'concurrent', $c->config->{basepath});
         $c->stash->{rest} = {success => "1",};
         return;
     }


### PR DESCRIPTION
To test: 

1. Create a BreedBase program (through local Breeding Insight Platform is probably easiest)
2. In the multiple trial upload, upload this file:
[BI-1164-studies.xls](https://github.com/Breeding-Insight/sgn/files/7892180/BI-1164-studies.xls)
 3. Check BrAPI observation units endpoint for data (http://localhost:7080/brapi/v2/observationunits)
 4. If the data isn't there, give it a couple of minutes before requesting changes on this PR, the materialized view might be refreshing still. I didn't make it wait for the refresh to finish to lower chances of something breaking on the front end. 