### PR TITLE
[BI-1320] Build correct code in BreedBase build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,8 +59,12 @@ jobs:
         id: extract_branch
 
       - name: Checkout sgn branch
-        working-directory: ./breedbase_dockerfile
-        run: cd cxgn/sgn & git status
+        working-directory: ./breedbase_dockerfile/cxgn/sgn
+        run: git switch ${steps.extract_branch.outputs.branch}
+
+      - name: Debug sgn branch
+        working-directory: ./breedbase_dockerfile/cxgn/sgn
+        run: git status
 
       - name: Set tag
         id: vars

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Checkout sgn branch
         working-directory: ./breedbase_dockerfile/cxgn/sgn
-        run: git switch ${steps.extract_branch.outputs.branch}
+        run: git switch ${{steps.extract_branch.outputs.branch}}
 
       - name: Debug sgn branch
         working-directory: ./breedbase_dockerfile/cxgn/sgn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ on:
     branches:
       - develop
       - master
-      - bug/BI-1320
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ on:
     branches:
       - develop
       - master
+      - bug/BI-1320
   workflow_dispatch:
 
 jobs:
@@ -56,6 +57,10 @@ jobs:
         shell: bash
         run: echo ::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})
         id: extract_branch
+
+      - name: Checkout sgn branch
+        working-directory: ./breedbase_dockerfile
+        run: cd cxgn/sgn & git status
 
       - name: Set tag
         id: vars


### PR DESCRIPTION
JIRA: https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1320

# Description

Looks like the breedbase build was not checking out the proper code before building the image, so the `master` branch was being built for develop as well as for master. I changed it so that it checks out the branch that it is being run on. 

Looks like this bug was introduced for the PR "Update docker images for develop and master" (https://github.com/Breeding-Insight/sgn/commit/32e9e4561417f55255977e3bce45f49ff4e669f6). The code checkout was not added when adding develop as a push candidate for the action. 


