### PR TITLE
[BI-1371] phenotype importer: parse ordinal categories

### DIFF
--- a/lib/CXGN/Phenotypes/StorePhenotypes.pm
+++ b/lib/CXGN/Phenotypes/StorePhenotypes.pm
@@ -367,7 +367,20 @@ sub verify {
                 }
                 if (exists($check_trait_category{$trait_cvterm_id})) {
                     my @trait_categories = split /\//, $check_trait_category{$trait_cvterm_id};
-                    my %trait_categories_hash = map { $_ => 1 } @trait_categories;
+                    my %trait_categories_hash;
+                    if ($check_trait_format{$trait_cvterm_id} eq 'Ordinal') {
+                        # Ordinal looks like <value>=<category>
+                        foreach my $ordinal_category (@trait_categories) {
+                            my @split_value = split('=', $ordinal_category);
+                            if (scalar(@split_value) >= 1) {
+                                $trait_categories_hash{$split_value[0]} = 1;
+                            }
+                        }
+                    } else {
+                        # Nominal, the category is just a value
+                        %trait_categories_hash = map { $_ => 1 } @trait_categories;
+                    }
+
                     if (!exists($trait_categories_hash{$trait_value})) {
                         $error_message = $error_message."<small>This trait value should be one of ".$check_trait_category{$trait_cvterm_id}.": <br/>Plot Name: ".$plot_name."<br/>Trait Name: ".$trait_name."<br/>Value: ".$trait_value."</small><hr>";
                     }


### PR DESCRIPTION
Description 
-----------------------------------------------------
Parses ordinal categories so that the phenotypic importer in breedbase can recognize values and validate the values. 

Merging into master so we can get this fix out to the production instances quickly. 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
