### PR TITLE
[BI-1405] POST trait: make method description not required

### DIFF
--- a/lib/CXGN/BrAPI/v2/Methods.pm
+++ b/lib/CXGN/BrAPI/v2/Methods.pm
@@ -181,14 +181,16 @@ sub store {
             }
         );
 
-        my $prop_description = $schema->resultset("Cv::Cvtermprop")->create(
-            {
-                cvterm_id => $cvterm_id,
-                type_id   => $method_description_id,
-                value     => $method_description,
-                rank      => 0
-            }
-        );
+        if ($method_description) {
+            my $prop_description = $schema->resultset("Cv::Cvtermprop")->create(
+                {
+                    cvterm_id => $cvterm_id,
+                    type_id   => $method_description_id,
+                    value     => $method_description,
+                    rank      => 0
+                }
+            );
+        }
 
         my $prop_class = $schema->resultset("Cv::Cvtermprop")->create(
             {

--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -3386,7 +3386,7 @@ sub observationvariable_list_POST {
 	_validate_request($c, 'ARRAY', $data, [
 		'observationVariableName',
 		{'scale' => ['dataType', 'scaleName']},
-		{'method' => ['methodName', 'methodClass', 'description']},
+		{'method' => ['methodName', 'methodClass']},
 		{'trait' => ['traitName', 'status']}
 	]);
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

JIRA: https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1405

Simple fix to make method description not required. 

Testing
-----------------------------------------------------

1. Create a trait through the UI without a method description
2. Edit that trait and add a method description
3. Edit that trait and clear the method description
4. Look in BreedBase to ensure nothing looks amiss. 

