### PR TITLE
[BI-1407] fix and simplify UpdateWizardMaterializedViewsForGenoProtocols Migration

### DIFF
--- a/db/00153/PatchMissingMaterializedViews.pm
+++ b/db/00153/PatchMissingMaterializedViews.pm
@@ -1,0 +1,150 @@
+#!/usr/bin/env perl
+
+
+=head1 NAME
+
+PatchMissingMaterializedViews.pm
+
+=head1 SYNOPSIS
+
+mx-run PatchMissingMaterializedViews [options] -H hostname -D dbname -u username [-F]
+
+this is a subclass of L<CXGN::Metadata::Dbpatch>
+see the perldoc of parent class for more details.
+
+=head1 DESCRIPTION
+
+Patches missing materialized views in the case that UpdateWizardMaterializedViewsForGenoProtocols wasn't able to run because of conflicts with later migrations.
+
+=head1 AUTHOR
+
+Chris Tucker (ct447@cornell.edu)
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2010 Boyce Thompson Institute for Plant Research
+
+This program is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut
+
+
+package PatchMissingMaterializedViews;
+
+use Moose;
+extends 'CXGN::Metadata::Dbpatch';
+
+
+has '+description' => ( default => <<'' );
+Patches missing materialized views in the case that UpdateWizardMaterializedViewsForGenoProtocols wasn't able to run because of conflicts with later migrations.
+
+
+sub patch {
+    my $self=shift;
+
+    print STDOUT "Executing the patch:\n " .   $self->name . ".\n\nDescription:\n  ".  $self->description . ".\n\nExecuted by:\n " .  $self->username . " .";
+
+    print STDOUT "\nChecking if this db_patch was executed before or if previous db_patches have been executed.\n";
+
+    print STDOUT "\nExecuting the SQL commands.\n";
+
+    $self->dbh->do(<<EOSQL);
+--do your SQL here
+DROP MATERIALIZED VIEW IF EXISTS public.genotyping_projectsxaccessions CASCADE;
+CREATE MATERIALIZED VIEW public.genotyping_projectsxaccessions AS
+ SELECT nd_experiment_project.project_id AS genotyping_project_id,
+    materialized_genoview.accession_id
+   FROM ((nd_experiment_project
+     JOIN nd_experiment_genotype ON ((nd_experiment_project.nd_experiment_id = nd_experiment_genotype.nd_experiment_id)))
+     JOIN materialized_genoview ON ((nd_experiment_genotype.genotype_id = materialized_genoview.genotype_id)))
+  WHERE (nd_experiment_project.project_id IN ( SELECT genotyping_projects.genotyping_project_id
+           FROM genotyping_projects))
+  GROUP BY nd_experiment_project.project_id, materialized_genoview.accession_id
+ WITH DATA;
+CREATE UNIQUE INDEX genotyping_projectsxaccessions_idx ON public.genotyping_projectsxaccessions(genotyping_project_id, accession_id) WITH (fillfactor=100);
+ALTER MATERIALIZED VIEW public.genotyping_projectsxaccessions OWNER TO web_usr;
+
+DROP MATERIALIZED VIEW IF EXISTS public.genotyping_projectsxbreeding_programs CASCADE;
+CREATE MATERIALIZED VIEW public.genotyping_projectsxbreeding_programs AS
+ SELECT project_relationship.subject_project_id AS genotyping_project_id,
+    project_relationship.object_project_id AS breeding_program_id
+   FROM project_relationship
+  WHERE ((project_relationship.type_id = ( SELECT cvterm.cvterm_id
+           FROM cvterm
+          WHERE ((cvterm.name)::text = 'breeding_program_trial_relationship'::text))) AND (project_relationship.subject_project_id IN ( SELECT genotyping_projects.genotyping_project_id
+           FROM genotyping_projects)))
+ WITH DATA;
+CREATE UNIQUE INDEX genotyping_projectsxbreeding_programs_idx ON public.genotyping_projectsxbreeding_programs(genotyping_project_id, breeding_program_id) WITH (fillfactor=100);
+ALTER MATERIALIZED VIEW public.genotyping_projectsxbreeding_programs OWNER TO web_usr;
+
+DROP MATERIALIZED VIEW IF EXISTS public.genotyping_protocolsxgenotyping_projects CASCADE;
+CREATE MATERIALIZED VIEW public.genotyping_protocolsxgenotyping_projects AS
+ SELECT genotyping_protocols.genotyping_protocol_id,
+    nd_experiment_project.project_id AS genotyping_project_id
+   FROM ((genotyping_protocols
+     JOIN nd_experiment_protocol ON ((genotyping_protocols.genotyping_protocol_id = nd_experiment_protocol.nd_protocol_id)))
+     JOIN nd_experiment_project ON ((nd_experiment_protocol.nd_experiment_id = nd_experiment_project.nd_experiment_id)))
+  GROUP BY genotyping_protocols.genotyping_protocol_id, nd_experiment_project.project_id
+ WITH DATA;
+CREATE UNIQUE INDEX genotyping_protocolsxgenotyping_projects_idx ON public.genotyping_protocolsxgenotyping_projects(genotyping_protocol_id, genotyping_project_id) WITH (fillfactor=100);
+ALTER MATERIALIZED VIEW public.genotyping_protocolsxgenotyping_projects OWNER TO web_usr;
+
+DROP MATERIALIZED VIEW IF EXISTS public.locationsxgenotyping_projects CASCADE;
+CREATE MATERIALIZED VIEW public.locationsxgenotyping_projects AS
+ SELECT projectprop.value AS location_id,
+    projectprop.project_id AS genotyping_project_id
+   FROM projectprop
+  WHERE ((projectprop.type_id = ( SELECT cvterm.cvterm_id
+           FROM cvterm
+          WHERE ((cvterm.name)::text = 'project location'::text))) AND (projectprop.value IN ( SELECT (locations.location_id)::text AS location_id
+           FROM locations)) AND (projectprop.project_id IN ( SELECT project.project_id
+           FROM (project
+             JOIN projectprop projectprop_1 USING (project_id))
+          WHERE ((projectprop_1.type_id = ( SELECT cvterm.cvterm_id
+                   FROM cvterm
+                  WHERE ((cvterm.name)::text = 'design'::text))) AND (projectprop_1.value = 'genotype_data_project'::text)))))
+ WITH DATA;
+CREATE UNIQUE INDEX locationsxgenotyping_projects_idx ON public.locationsxgenotyping_projects(location_id, genotyping_project_id) WITH (fillfactor=100);
+ALTER MATERIALIZED VIEW public.locationsxgenotyping_projects OWNER TO web_usr;
+
+CREATE MATERIALIZED VIEW public.trait_componentsXtraits AS
+SELECT traits.trait_id,
+trait_component.cvterm_id AS trait_component_id
+FROM traits
+JOIN cvterm_relationship ON(traits.trait_id = cvterm_relationship.object_id AND cvterm_relationship.type_id = (SELECT cvterm_id from cvterm where name = 'contains'))
+JOIN cvterm trait_component ON(cvterm_relationship.subject_id = trait_component.cvterm_id)
+GROUP BY 1,2
+WITH DATA;
+CREATE UNIQUE INDEX trait_componentsXtraits_idx ON public.trait_componentsXtraits(trait_component_id, trait_id) WITH (fillfactor=100);
+ALTER MATERIALIZED VIEW trait_componentsXtraits OWNER TO web_usr;
+INSERT INTO matviews (mv_name, currently_refreshing, last_refresh) VALUES ('trait_componentsXtraits', FALSE, CURRENT_TIMESTAMP);
+
+DROP MATERIALIZED VIEW IF EXISTS public.trialsxgenotyping_projects CASCADE;
+CREATE MATERIALIZED VIEW public.trialsxgenotyping_projects AS
+ SELECT trials.trial_id,
+    nd_experiment_project.project_id AS genotyping_project_id
+   FROM ((((trials
+     JOIN materialized_phenoview ON ((trials.trial_id = materialized_phenoview.trial_id)))
+     JOIN materialized_genoview ON ((materialized_phenoview.accession_id = materialized_genoview.accession_id)))
+     JOIN nd_experiment_genotype ON ((materialized_genoview.genotype_id = nd_experiment_genotype.genotype_id)))
+     JOIN nd_experiment_project ON ((nd_experiment_genotype.nd_experiment_id = nd_experiment_project.nd_experiment_id)))
+  WHERE (nd_experiment_project.project_id IN ( SELECT projectprop.project_id
+           FROM projectprop
+          WHERE ((projectprop.type_id IN ( SELECT cvterm.cvterm_id
+                   FROM cvterm
+                  WHERE ((cvterm.name)::text = 'design'::text))) AND (projectprop.value = 'genotype_data_project'::text))))
+  GROUP BY trials.trial_id, nd_experiment_project.project_id
+ WITH DATA;
+CREATE UNIQUE INDEX trialsxgenotyping_projects_idx ON public.trialsxgenotyping_projects(trial_id, genotyping_project_id) WITH (fillfactor=100);
+ALTER MATERIALIZED VIEW public.trialsxgenotyping_projects OWNER TO web_usr;
+
+EOSQL
+
+    print "You're done!\n";
+}
+
+
+####
+1; #
+####


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
JIRA Issue: https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1407

The issue reported is caused by the migrations not being run. The migrations are not running because there is an error in the database migration `00135/UpdateWizardMaterializedViewsForGenoProtocols` that is caused and persisted by us running the database migrations out of order before.

Here is how the error came about: 
1. We set up our BreedBase instances and ran the migrations
2. By default, the migrations are skipped if one fails and the ones after it are attempted. 
3. In our instances, the UpdateWizardMaterializedViewsForGenoProtocols errored out because it was missing a column in a group by method, and that one was skipped. 
4. The migration 00143/SpeedUpMatviews was run successfully. 
5. Tim added a check to the `run_all_patches` file that stops the migrations when an error was returned. 
6. Now when we try to run UpdateWizardMaterializedViewsForGenoProtocols, there is a conflict with the changes in this migration compared to the SpeedUpMatviews migration so the migrations always error out and new migrations aren't executed. 

The fix:
To fix this, I created a new patch that recreates all of the views in UpdateWizardMaterializedViewsForGenoProtocols that aren't recreated in later migrations. For servers where we can't get past the errors in UpdateWizardMaterializedViewsForGenoProtocols, we will manually mark those as complete in the database. I did it this way so that its more likely this work can get merged into breedbase. 

How I determined unique migrations: 
1. Pulled out all of the view names in the UpdateWizardMaterializedViewsForGenoProtocols file. (file below)
2. Pulled out all of the view names in SpeedUpMatviews (file below)
3. Pulled out all of the view names in AddMissingSeedlotsViews (file below)
  - This is another migration after UpdateWizardMaterializedViewsForGenoProtocols that modifies the same views. 
4. Compared the later two files with UpdateWizardMaterializedViewsForGenoProtocols to find unique views. (analysis below)
5. Double checked the unique queries to make sure they weren't already views or materialized views (query below). 

Views sql query: 

```
 select table_name from INFORMATION_SCHEMA.views where table_name in (
 	'genotyping_projectsxaccessions', 
 	'genotyping_projectsxbreeding_programs',
 	'genotyping_protocolsxgenotyping_projects', 
 	'locationsxgenotyping_projects', 
 	'trait_componentsXtraits', 
 	'trialsxgenotyping_projects'
)
```

[AddMissingSeedlotViews.txt](https://github.com/Breeding-Insight/sgn/files/8172344/AddMissingSeedlotViews.txt)
[missing_view_analysis.xlsx](https://github.com/Breeding-Insight/sgn/files/8172345/missing_view_analysis.xlsx)
[SpeedUpMatviews_Tables.txt](https://github.com/Breeding-Insight/sgn/files/8172346/SpeedUpMatviews_Tables.txt)
[UpdateWizardMaterializedViewsForGenoProtocols_Tables.txt](https://github.com/Breeding-Insight/sgn/files/8172347/UpdateWizardMaterializedViewsForGenoProtocols_Tables.txt)

How to test: 
1. Check that `UpdateWizardMaterializedViewsForGenoProtocols` is not in your migrations table.
  - `select * from metadata.md_dbversion md where patch_name = 'UpdateWizardMaterializedViewsForGenoProtocols'`
2. Manually skip that migration with the query added to the breedbase_configs repo. 
2. Run the migrations
3. Check if the new patch ran successfully.
4. Check your database to see missing materialized views are now created. 


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
