### PR TITLE
[BI-1435] GET observations: handle null observation date

### DIFF
--- a/lib/CXGN/BrAPI/TimeUtils.pm
+++ b/lib/CXGN/BrAPI/TimeUtils.pm
@@ -2,7 +2,9 @@ package CXGN::BrAPI::TimeUtils;
 
 sub db_time_to_iso {
     my $db_time = shift;
-    return $db_time."Z";
+    if ($db_time) {
+        return $db_time."Z";
+    }
 }
 
 sub db_time_to_iso_utc {


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Adds a check for null observation dates. 

## Dependencies
biapi: BI-1435
biweb: release/0.5

## Testing
1. Upload trials to get studies into your program (Change program name and germplasm name)
2. Upload the data file to get data into your program (Change trait name)
3. Query brapi GET /observations and check that `observationTimeStamp` is null and not "Z"

[RelTestBBData.xls](https://github.com/Breeding-Insight/sgn/files/8289336/RelTestBBData.xls)
[ReltestBBTrials.xls](https://github.com/Breeding-Insight/sgn/files/8289337/ReltestBBTrials.xls)


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
