### PR TITLE
[BI-1434] Allow data upload for nominal traits in breedbase importer

### DIFF
--- a/lib/CXGN/Phenotypes/StorePhenotypes.pm
+++ b/lib/CXGN/Phenotypes/StorePhenotypes.pm
@@ -368,7 +368,7 @@ sub verify {
                 if (exists($check_trait_category{$trait_cvterm_id})) {
                     my @trait_categories = split /\//, $check_trait_category{$trait_cvterm_id};
                     my %trait_categories_hash;
-                    if ($check_trait_format{$trait_cvterm_id} eq 'Ordinal') {
+                    if ($check_trait_format{$trait_cvterm_id} eq 'Ordinal' || $check_trait_format{$trait_cvterm_id} eq 'Nominal') {
                         # Ordinal looks like <value>=<category>
                         foreach my $ordinal_category (@trait_categories) {
                             my @split_value = split('=', $ordinal_category);
@@ -377,7 +377,7 @@ sub verify {
                             }
                         }
                     } else {
-                        # Nominal, the category is just a value
+                        # Catch everything else
                         %trait_categories_hash = map { $_ => 1 } @trait_categories;
                     }
 


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------

Nominal traits are stored like `1=/2=`. I fixed the parsing of these in phenotype upload. 


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
