### PR TITLE
[BI-1361] BUG: Breedbase doesn't allow for program names longer than 20 characters

### DIFF
--- a/db/00154/IncreaseCharLimitSgnPeopleSPRoles.pm
+++ b/db/00154/IncreaseCharLimitSgnPeopleSPRoles.pm
@@ -1,0 +1,70 @@
+#!/usr/bin/env perl
+
+
+=head1 NAME
+
+  IncreaseCharLimitSgnPeopleSPRoles.pm
+
+=head1 SYNOPSIS
+
+mx-run ThisPackageName [options] -H hostname -D dbname -u username [-F]
+
+this is a subclass of L<CXGN::Metadata::Dbpatch>
+see the perldoc of parent class for more details.
+
+=head1 DESCRIPTION
+
+This is a test dummy patch.
+This subclass uses L<Moose>. The parent class uses L<MooseX::Runnable>
+
+=head1 AUTHOR
+
+ Dave Meidlinger<djm226@cornell.edu>
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2010 Boyce Thompson Institute for Plant Research
+
+This program is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut
+
+
+package IncreaseCharLimitSgnPeopleSPRoles;
+
+use Moose;
+use Bio::Chado::Schema;
+extends 'CXGN::Metadata::Dbpatch';
+
+
+has '+description' => ( default => <<'' );
+This patch will increase the character limit to 255 for the name field of the sgn_people.sp_roles table.
+
+has '+prereq' => (
+    default => sub {
+        [],
+    },
+  );
+
+sub patch {
+    my $self=shift;
+
+    print STDOUT "Executing the patch:\n " .   $self->name . ".\n\nDescription:\n  ".  $self->description . ".\n\nExecuted by:\n " .  $self->username . " .";
+    print STDOUT "\nChecking if this db_patch was executed before or if previous db_patches have been executed.\n";
+    print STDOUT "\nExecuting the SQL commands.\n";
+
+    $self->dbh->do(<<EOSQL);
+--do your SQL here
+--
+ALTER TABLE sgn_people.sp_roles ALTER COLUMN name TYPE VARCHAR (255);
+
+EOSQL
+
+print "You're done!\n";
+}
+
+
+####
+1; #
+####


### PR DESCRIPTION
Description 
-----------------------------------------------------
[BI-1361](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1361)
The character limit is increased from 20 to 255 for the name column of the table sgn_people.sp-roles.

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
