### PR TITLE
[BI-1421] - Add Synonym Support to Germplasm and Other Improvements

### DIFF
--- a/lib/CXGN/BrAPI/v2/ExternalReferences.pm
+++ b/lib/CXGN/BrAPI/v2/ExternalReferences.pm
@@ -182,11 +182,7 @@ sub _remove_external_references {
         push @ids, @r[0];
     }
     my $list_ids = join ("," , @ids);
-
-    if (scalar(@ids) > 0) {
-        my $delete_dbxref_query = "delete from dbxref where dbxref_id in ($list_ids)";
-        $self->bcs_schema->storage()->dbh()->prepare($delete_dbxref_query)->execute();
-    }
+    
     # Clear $table_dbxref
     my $delete_table_dbxref_query = "delete from $table\_dbxref where $table_id = $id";
     $self->bcs_schema->storage()->dbh()->prepare($delete_table_dbxref_query)->execute();

--- a/lib/CXGN/BrAPI/v2/ExternalReferences.pm
+++ b/lib/CXGN/BrAPI/v2/ExternalReferences.pm
@@ -168,22 +168,7 @@ sub _remove_external_references {
     my $table_id = $self->table_id_key();
     my $id = $self->id();
 
-    # Find dbxref connected to the external references
-    my $query = "select dbxref.dbxref_id from
-                    $table\_dbxref as ref join
-                    dbxref on (ref.dbxref_id=dbxref.dbxref_id)
-                    where ref.$table_id = $id";
-    my $sth = $self->bcs_schema->storage()->dbh()->prepare($query);
-    $sth->execute();
-
-    # Clear dbxref
-    my @ids;
-    while (my @r = $sth->fetchrow_array()) {
-        push @ids, @r[0];
-    }
-    my $list_ids = join ("," , @ids);
-    
-    # Clear $table_dbxref
+    # Clear $table_dbxref, we'll leave the dbxref because those can be shared
     my $delete_table_dbxref_query = "delete from $table\_dbxref where $table_id = $id";
     $self->bcs_schema->storage()->dbh()->prepare($delete_table_dbxref_query)->execute();
 }

--- a/lib/CXGN/Stock.pm
+++ b/lib/CXGN/Stock.pm
@@ -1417,8 +1417,7 @@ sub _remove_stockprop_all_of_type {
     my $value = shift;
     my $type_id = SGN::Model::Cvterm->get_cvterm_row($self->schema, $type, 'stock_property')->cvterm_id();
     my $rs = $self->schema()->resultset("Stock::Stockprop")->search( { type_id=>$type_id, stock_id => $self->stock_id() } );
-
-    print 'ROWCOUNT! ' . $rs->count() . $value;
+    
     if ($rs->count() > 0) {
         while (my $row = $rs->next()) {
             $row->delete();

--- a/lib/CXGN/Stock.pm
+++ b/lib/CXGN/Stock.pm
@@ -1410,6 +1410,30 @@ sub _remove_stockprop {
 
 }
 
+sub _remove_stockprop_all_of_type {
+
+    my $self = shift;
+    my $type = shift;
+    my $value = shift;
+    my $type_id = SGN::Model::Cvterm->get_cvterm_row($self->schema, $type, 'stock_property')->cvterm_id();
+    my $rs = $self->schema()->resultset("Stock::Stockprop")->search( { type_id=>$type_id, stock_id => $self->stock_id() } );
+
+    print 'ROWCOUNT! ' . $rs->count() . $value;
+    if ($rs->count() > 0) {
+        while (my $row = $rs->next()) {
+            $row->delete();
+        }
+        return 1;
+    }
+    elsif ($rs->count() == 0) {
+        return 0;
+    }
+    else {
+        print STDERR "Error removing stockprop from stock ".$self->stock_id().". Please check this manually.\n";
+        return 0;
+    }
+}
+
 sub _retrieve_organismprop {
     my $self = shift;
     my $type = shift;
@@ -1520,19 +1544,17 @@ sub _store_parent_relationship {
     }
 }
 
-sub _update_parent_relationship {
+sub _remove_parent_relationship {
     my $self = shift;
     my $relationship_type = shift;
-    my $parent_accession = shift;
-    my $cross_type = shift;
-    print STDERR "***STOCK.PM Updating parent relationship\n\n";
     my $parent_cvterm_id =  SGN::Model::Cvterm->get_cvterm_row($self->schema, $relationship_type,'stock_relationship')->cvterm_id();
-    my $pop_rs = $self->stock->search_related('stock_relationship_subjects', {'type_id'=>$parent_cvterm_id});
-    while (my $r=$pop_rs->next){
+    my $rs = $self->schema()->resultset("Stock::StockRelationship")->search( { type_id=>$parent_cvterm_id, object_id => $self->stock_id() } );
+
+    while (my $r=$rs->next){
         $r->delete();
     }
-    $self->_store_population_relationship($relationship_type, $parent_accession, $cross_type);
 }
+
 ###
 
 =head2 _new_metadata_id()

--- a/lib/CXGN/Stock/Accession.pm
+++ b/lib/CXGN/Stock/Accession.pm
@@ -419,9 +419,12 @@ sub store {
     if ($self->germplasmSeedSource){
         $self->_update_stockprop('seed source', $self->germplasmSeedSource);
     }
+    # Delete synonyms
+    $self->_remove_stockprop_all_of_type('stock_synonym');
+    # Reinsert
     if ($self->synonyms){
         foreach (@{$self->synonyms}){
-            $self->_update_stockprop('stock_synonym', $_);
+            $self->_store_stockprop('stock_synonym', $_);
         }
     }
     if ($self->instituteCode){
@@ -450,10 +453,12 @@ sub store {
             $self->_update_stockprop('donor PUI', $_->{germplasmPUI});
         }
     }
+    $self->_remove_parent_relationship('female_parent');
     if ($self->mother_accession) {
         my $return = $self->_store_parent_relationship('female_parent', $self->mother_accession, 'biparental');
         # TODO: delete accession if error and return error
     }
+    $self->_remove_parent_relationship('male_parent');
     if ($self->father_accession) {
         my $return = $self->_store_parent_relationship('male_parent', $self->father_accession, 'biparental');
         # TODO: delete accession if error and return error


### PR DESCRIPTION
Added the following improvements to BreedBase germplasm:

1. Support for multiple synonyms
2. Updating of germplasm pedigree
3. Updating of external references rather than just appending new ones (should apply to all brapi models).

## Testing
- Use an api client like Insomnia to POST and PUT germplasm to test out the changes listed above. 

