### PR TITLE
[BI-1189] - Change seasons POST endpoint to comply with BrAPI spec

### DIFF
--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -591,6 +591,7 @@ sub seasons : Chained('brapi') PathPart('seasons') Args(0) : ActionClass('REST')
 sub seasons_POST {
 	my $self = shift;
 	my $c = shift;
+	my ($auth, $user_id) = _authenticate_user($c);
 	my $clean_inputs = $c->stash->{clean_inputs};
 	my $postedData = $clean_inputs;
 	my @data;

--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -589,9 +589,23 @@ sub observation_levels_GET {
 sub seasons : Chained('brapi') PathPart('seasons') Args(0) : ActionClass('REST') { }
 
 sub seasons_POST {
-    my $self = shift;
-    my $c = shift;
-    seasons_process($self, $c);
+	my $self = shift;
+	my $c = shift;
+	my $clean_inputs = $c->stash->{clean_inputs};
+	my $postedData = $clean_inputs;
+	my @data;
+	foreach my $season (values %{$postedData}) {
+		push @data, {
+			seasonDbId=>$season->{year},
+			season=>undef,
+			year=>$season->{year}
+		}
+	}
+	my $pagination = CXGN::BrAPI::Pagination->pagination_response(scalar(@data), scalar(@data), 1);
+	my %result = (data=>\@data);
+	my @data_files;
+	my $status;
+	_standard_response_construction($c, CXGN::BrAPI::JSONResponse->return_success(\%result, $pagination, \@data_files, $status, "Season created successfully"));
 }
 
 sub seasons_GET {


### PR DESCRIPTION
Original implementation was a proxy to the GET endpoint, and just returned the seasons that existed.  Breedbase doesn't save seasons separate from a study, so the new implementation creates a mock season with the seasonDbId being the same value as the year (because that's how Breedbase returns it from the GET endpoint).
