### PR TITLE
[BI-744] PUT observations: Add check to prevent null array access

### DIFF
--- a/lib/CXGN/Phenotypes/StorePhenotypes.pm
+++ b/lib/CXGN/Phenotypes/StorePhenotypes.pm
@@ -814,9 +814,12 @@ sub delete_previous_phenotypes {
         push @{$phenotype_ids_and_nd_experiment_ids_to_delete{nd_experiment_ids}}, $nd_experiment_id;
         push @deleted_phenotypes, [$file_id, $phenotype_id, $nd_experiment_id];
     }
-    my $delete_phenotype_values_error = CXGN::Project::delete_phenotype_values_and_nd_experiment_md_values($self->dbhost, $self->dbname, $self->dbuser, $self->dbpass, $self->temp_file_nd_experiment_id, $self->basepath, $self->bcs_schema, \%phenotype_ids_and_nd_experiment_ids_to_delete);
-    if ($delete_phenotype_values_error) {
-        die "Error deleting phenotype values ".$delete_phenotype_values_error."\n";
+
+    if (scalar(@deleted_phenotypes) > 0) {
+        my $delete_phenotype_values_error = CXGN::Project::delete_phenotype_values_and_nd_experiment_md_values($self->dbhost, $self->dbname, $self->dbuser, $self->dbpass, $self->temp_file_nd_experiment_id, $self->basepath, $self->bcs_schema, \%phenotype_ids_and_nd_experiment_ids_to_delete);
+        if ($delete_phenotype_values_error) {
+            die "Error deleting phenotype values ".$delete_phenotype_values_error."\n";
+        }
     }
 
     return @deleted_phenotypes;


### PR DESCRIPTION
Adds a simple array size check to prevent a null array access error. This error was preventing updating traits in Field Book. 

## Prereqs
FieldBook 5.0.7
FieldBook 5.2 (test with both)

## Test
1. Collect some data in field book
2. Export data to breedbase
3. Edit the collected data
4. Export the collected traits
5. Check in the database that the observations (in the `phenotypes` table) were updated properly. 