### PR TITLE
[BI-1364] - Unable to search by multiple externalRef ID/Source

### DIFF
--- a/lib/CXGN/BrAPI/v2/ExternalReferences.pm
+++ b/lib/CXGN/BrAPI/v2/ExternalReferences.pm
@@ -66,6 +66,7 @@ sub search {
         if($reference_source eq 'DOI') {
             $reference_id = ($url) ? "$url$accession" : "doi:$accession";
         } else {
+            $url = ($url) ? $url : "";
             $reference_id = ($accession) ? "$url$accession" : $url;
         }
 

--- a/lib/CXGN/BrAPI/v2/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationVariables.pm
@@ -131,16 +131,26 @@ sub search {
         my @sub_and_wheres;
         push @sub_and_wheres, "cvterm.cv_id = $cv_id";
         push @sub_and_wheres, "reltype.name='VARIABLE_OF'";
+        my @dbxrefid_where;
         if (scalar(@dbxref_ids)>0){
-            # TODO: Should this be OR?
             foreach (@dbxref_ids) {
-                push @sub_and_wheres, "dbxref.accession = '$_'";
+                push @dbxrefid_where, "dbxref.accession = '$_'";
             }
         }
+        if(scalar(@dbxrefid_where)>0) {
+            my $dbxref_id_where_str = '('. (join ' OR ', @dbxrefid_where) . ')';
+            push @sub_and_wheres, $dbxref_id_where_str;
+        }
+
+        my @dbxref_term_where;
         if (scalar(@dbxref_terms)>0) {
             foreach (@dbxref_terms) {
-                push @sub_and_wheres, "db.name = '$_'";
+                push @dbxref_term_where, "db.name = '$_'";
             }
+        }
+        if(scalar(@dbxref_term_where)>0) {
+            my $dbxref_term_where_str = '('. (join ' OR ', @dbxref_term_where) . ')';
+            push @sub_and_wheres, $dbxref_term_where_str;
         }
 
         my $sub_and_where_clause = join ' AND ', @sub_and_wheres;


### PR DESCRIPTION
Description 
-----------------------------------------------------

When calling the `/search/variables` endpoint and passing in a list of `externalReferenceIds` or `externalReferenceSources`, the original code AND'd these values together in the SQL query.  This has been changed to now OR the values together in the SQL query.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.

Testing
-------
To test BI-1364, make sure that the program sharing its ontology is configured to store its data in BreedBase, and there is more than one ontology term created for the program.  Set up a new share, then go to the program that will subscribe and verify you can subscribe to the program, and then see the ontology terms on the ontology page.