### PR TITLE
BI-1507 - Updating list and germplasm search to filter by externalReference

### DIFF
--- a/lib/CXGN/BrAPI/v2/Germplasm.pm
+++ b/lib/CXGN/BrAPI/v2/Germplasm.pm
@@ -122,6 +122,8 @@ sub search {
         },
         trial_id_list=>$study_db_id,
         trial_name_list=>$study_names,
+        external_ref_id_list=>$external_reference_id_arrayref,
+        external_ref_source_list=>$external_reference_source_arrayref,
         limit=>$limit,
         offset=>$offset,
         display_pedigree=>1
@@ -168,28 +170,12 @@ sub search {
 
         #Get external references and check for search params
         my @references;
-        my $external_reference_id = $external_reference_id_arrayref->[0];
-        my $external_reference_source = $external_reference_source_arrayref->[0];
-        my $match_found = $external_reference_id || $external_reference_source ? 0 : 1;
         if (%$reference_result{$_->{stock_id}}){
             foreach (@{%$reference_result{$_->{stock_id}}}){
 
                 push @references, $_;
-                if (!$match_found) {
-                    my $source_found = $external_reference_source ? 0 : 1;
-                    my $id_found = $external_reference_id ? 0 : 1;
-                    if (!$id_found) {
-                        $id_found = $external_reference_id && $_->{referenceID} eq $external_reference_id ? 1 : 0;
-                    }
-                    if (!$source_found) {
-                        $source_found = $external_reference_source && $_->{referenceSource} eq $external_reference_source ? 1 : 0;
-                    }
-                    $match_found = $id_found && $source_found;
-                }
             }
         }
-        # Skip this germplasm if an external reference match was not found
-        if (!$match_found) { next; }
 
         my $female_parent_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'female_parent', 'stock_relationship')->cvterm_id();
         my $q = "SELECT value FROM stock_relationship WHERE object_id = ? AND type_id = ?;";

--- a/lib/CXGN/Stock/Search.pm
+++ b/lib/CXGN/Stock/Search.pm
@@ -537,18 +537,7 @@ sub search {
         }
 
         $stock_xref_search_sql = $stock_xref_search_sql . join(" and ", @xref_search_ands);
-
-        my $h = $schema->storage->dbh()->prepare($stock_xref_search_sql);
-        $h->execute();
-
-        my @stockxref_filtered_stock_ids;
-        while (my $stock_id = $h->fetchrow_array()) {
-            push @stockxref_filtered_stock_ids, $stock_id;
-        }
-
-        if (scalar(@stockxref_filtered_stock_ids)>0){
-            $search_query->{'me.stock_id'} = {'in'=>\@stockxref_filtered_stock_ids};
-        }
+        $search_query->{'me.stock_id'} = {'in'=>\$stock_xref_search_sql};
     }
 
     my $rs = $schema->resultset("Stock::Stock")->search(


### PR DESCRIPTION
Description
-----------------------------------------------------
- Update the Stock search method to accept externalReference information as parameters, and to filter by stock that match the externalReference(s) in the SQL query.  This brings the BrAPI Germplasm search more in line with the spec.
- Update the BrAPI List search to filter by externalReference(s).  This brings the BrAPI List search more in line with the spec.


Checklist
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
