### PR TITLE
[BI-1575] return correct JSON for 'Get - /seasons/{seasonDbId}'

### DIFF
--- a/lib/CXGN/BrAPI/v2/Seasons.pm
+++ b/lib/CXGN/BrAPI/v2/Seasons.pm
@@ -23,7 +23,6 @@ sub search {
     my $page_size = $self->page_size;
     my $page = $self->page;
     my $status = $self->status;
-
     my $year_filter = $params->{seasonDbId} || ($params->{year} || ());
 
     my @data;
@@ -64,7 +63,6 @@ sub detail {
     my $page_size = $self->page_size;
     my $page = $self->page;
     my $status = $self->status;
-
     my @data;
     my $total_count = 0;
     my $year_cvterm_id = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema,'project year', 'project_property')->cvterm_id();
@@ -92,13 +90,13 @@ sub detail {
         my $projectprop_id = $_->[2] ? $_->[2] : '';
         push @data, {
             seasonDbId=>qq|$projectprop_id|,
-            season=>$season,
-            year=>$year
+            seasonName=>$season,
+            year=>int($year)
         };
     }
-    my %result = (data=>\@data);
+
     my @data_files;
-    return CXGN::BrAPI::JSONResponse->return_success(\%result, $pagination, \@data_files, $status, 'Seasons list result constructed');
+    return CXGN::BrAPI::JSONResponse->return_success(@data, $pagination, \@data_files, $status, 'Seasons list result constructed');
 }
 
 1;


### PR DESCRIPTION
**Description** 

When a program stores data in a BreedBase server, and an existing experiment (trial) with an existing environment (study) is imported; the confirmation table shows the Env Year as a blank instead of the numeric year.

The root cause is that breedbase was not returning the expected BrAPI values for 'Get - /seasons/{seasonDbId}'. Spesifically the “result” element is incorrect: 

    There should not be a ‘data’ array element

    The element should be called ‘seasonName’ not ‘season’

    The ‘year’ element should be an integer, not a string

-----------------------------------------------------


<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [X] Bug fix
  - [X] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
