### PR TITLE
BI-1649 - BreedBase fails on uploading a trial file where synonyms have square brackets ([..]) in the name 

### DIFF
--- a/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignExcelFormat.pm
+++ b/lib/CXGN/Trial/ParseUpload/Plugin/MultipleTrialDesignExcelFormat.pm
@@ -517,7 +517,7 @@ sub _validate_with_plugin {
 
       push @warning_messages, "File Accession $matched_synonym is a synonym of database accession $found_acc_name_from_synonym ";
 
-      @accessions = grep !/$matched_synonym/, @accessions;
+      @accessions = grep !/\Q$matched_synonym/, @accessions;
       push @accessions, $found_acc_name_from_synonym;
   }
 


### PR DESCRIPTION
Description
-----------------------------------------------------

Updated the validation in `MultipleTrialDesignExcelFormat.pm` to use string comparison in a `grep` command instead of regex.

Failure was happening because synonym had square brackets and a "range" defined (ex: `[PROG-1]`), and the original code was interpreting that as a regex range (expecting something like `[a-z]`)


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
