### PR TITLE
BI-1639 - BreedBase - Composed traits are not returned in BrAPI GET /variables endpoint

### DIFF
--- a/lib/CXGN/BrAPI/v2/ObservationVariables.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationVariables.pm
@@ -99,10 +99,6 @@ sub search {
     my $join = '';
     my @and_wheres;
 
-    # only get cvterms for the cv for the configured trait ontology
-    push @and_wheres, "cvterm.cv_id=".$self->trait_ontology_cv_id;
-
-
     if (scalar(@trait_ids)>0){
         my $trait_ids_sql = join ',', @trait_ids;
         push @and_wheres, "cvterm.cvterm_id IN ($trait_ids_sql)";


### PR DESCRIPTION
Description
-----------------------------------------------------
Removed the line that was adding a where clause to the observation variables query which was restricting the result set to only observation variables that exist within the ontology that was configured in the `trait_ontology_cv_id` config property

Testing
-----------------------------------------------------

1. Enable the ability to define composed traits by updating your `sgn_local.conf` to include:

```
composable_cvs trait,object,tod,toy,unit,method
composable_cvs_allowed_combinations Agronomic|trait+toy,Metabolic|trait+object+tod+toy+unit+method
composable_cvterm_delimiter |
composable_cvterm_format concise
```

2. Navigate to `<breedbase host>/tools/compose/` and follow the on-screen instructions to create a new composed trait.
3. In your rest client of choice, make a GET call to `<breedbase host>/brapi/v2/variables` and confirm that the composed trait shows up in the list


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
