### PR TITLE
[BI-1579] - Breedbase progeny endpoint not BrAPI-compliant

### DIFF
--- a/lib/CXGN/BrAPI/v2/Germplasm.pm
+++ b/lib/CXGN/BrAPI/v2/Germplasm.pm
@@ -402,8 +402,6 @@ sub germplasm_progeny {
     my $self = shift;
     my $inputs = shift;
     my $stock_id = $inputs->{stock_id};
-    my $page_size = $self->page_size;
-    my $page = $self->page;
     my $status = $self->status;
     my $mother_cvterm = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'female_parent', 'stock_relationship')->cvterm_id();
     my $father_cvterm = SGN::Model::Cvterm->get_cvterm_row($self->bcs_schema, 'male_parent', 'stock_relationship')->cvterm_id();
@@ -449,6 +447,11 @@ sub germplasm_progeny {
         }
     }
     my $total_count = scalar @{$full_data};
+    my $page_size = 10;
+    if ($total_count > $page_size){
+        $page_size = $total_count;
+    }
+    my $page = 0;
     my $last_item = $page_size*($page+1)-1;
     if($last_item > $total_count-1){
         $last_item = $total_count-1;

--- a/lib/CXGN/BrAPI/v2/Germplasm.pm
+++ b/lib/CXGN/BrAPI/v2/Germplasm.pm
@@ -452,14 +452,10 @@ sub germplasm_progeny {
         $page_size = $total_count;
     }
     my $page = 0;
-    my $last_item = $page_size*($page+1)-1;
-    if($last_item > $total_count-1){
-        $last_item = $total_count-1;
-    }
     my $result = {
         germplasmName=>$stock->uniquename,
         germplasmDbId=>$stock_id,
-        progeny=>[@{$full_data}[$page_size*$page .. $last_item]],
+        progeny=>[@{$full_data}],
     };
     my @data_files;
     my $pagination = CXGN::BrAPI::Pagination->pagination_response($total_count,$page_size,$page);


### PR DESCRIPTION
# Description
**Story:** [BI-1579 - Breedbase progeny endpoint not BrAPI-compliant](https://breedinginsight.atlassian.net/browse/BI-1579) /  [BI-1641 - Pedigree Viewer Parent button blinks and doesn't return any parents](https://breedinginsight.atlassian.net/browse/BI-1641) 

Modified Germplasm.pm to retrieve all progeny values on one page. This resolves the issue where the BrAPI endpoint for progeny doesn't expect a page or pageSize, leading to nonstop blinking loading dot when trying to expand pedigrees where a parent had greater than the default pagesize, 10, progeny.

# Dependencies
bi-web/release/0.7
bi-api/release/0.7

# Testing
- Upload germplasm file where at least one parent has more than 10 progeny. (see BI-1641 for example file)
- Open germplasm details page for parent with >10 progeny and expand pedigree tree (should be able to expand, if with a bit of a delay)
- Open germplasm details page for one of aforementioned progeny and expand pedigree tree (should be able to expand, if with a bit of a delay)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] I have run TAF: _\<please include a link to TAF run>_
