### PR TITLE
BI-1683 - Missing female parent in biparental cross results in dropped male parent v0.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,20 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Get breedbase_dockerfile
+        if: startsWith(steps.extract_branch.outputs.branch, 'feature/') || startsWith(steps.extract_branch.outputs.branch, 'bug/')
         uses: actions/checkout@master
         with:
           repository: Breeding-Insight/breedbase_dockerfile
           path: breedbase_dockerfile
+          ref: 'develop'
+
+      - name: Get breedbase_dockerfile
+        if: startsWith(steps.extract_branch.outputs.branch, 'hotfix/')
+        uses: actions/checkout@master
+        with:
+          repository: Breeding-Insight/breedbase_dockerfile
+          path: breedbase_dockerfile
+          ref: 'master'
 
       - name: Get the submodules
         working-directory: ./breedbase_dockerfile

--- a/lib/CXGN/BrAPI/v2/Germplasm.pm
+++ b/lib/CXGN/BrAPI/v2/Germplasm.pm
@@ -631,7 +631,7 @@ sub store {
     # Check if pedigree parents don't exist
     my $missing_parents = '';
     foreach (@$pedigree_parents){
-        if (scalar($_) > 0 && exists($accessions_missing_hash{$_})){
+        if (length($_) > 0 && exists($accessions_missing_hash{$_})){
             $missing_parents = $missing_parents . $_ ."," ;
         }
     }
@@ -704,7 +704,7 @@ sub store {
             }
             my $pedigree = $params->{pedigree} || undef;
             my $pedigree_array = _process_pedigree_string($pedigree);
-            my $mother = defined $pedigree_array && scalar(@$pedigree_array) > 0 && scalar(@$pedigree_array[0]) > 0 ? @$pedigree_array[0] : undef;
+            my $mother = defined $pedigree_array && scalar(@$pedigree_array) > 0 && length(@$pedigree_array[0]) > 0 ? @$pedigree_array[0] : undef;
             my $father = defined $pedigree_array && scalar(@$pedigree_array) > 1 ? @$pedigree_array[1] : undef;
             my $synonyms = $params->{synonyms} || [];
             my @synonymNames;

--- a/lib/CXGN/BrAPI/v2/Germplasm.pm
+++ b/lib/CXGN/BrAPI/v2/Germplasm.pm
@@ -631,7 +631,7 @@ sub store {
     # Check if pedigree parents don't exist
     my $missing_parents = '';
     foreach (@$pedigree_parents){
-        if (exists($accessions_missing_hash{$_})){
+        if (scalar($_) > 0 && exists($accessions_missing_hash{$_})){
             $missing_parents = $missing_parents . $_ ."," ;
         }
     }
@@ -704,7 +704,7 @@ sub store {
             }
             my $pedigree = $params->{pedigree} || undef;
             my $pedigree_array = _process_pedigree_string($pedigree);
-            my $mother = defined $pedigree_array && scalar(@$pedigree_array) > 0 ? @$pedigree_array[0] : undef;
+            my $mother = defined $pedigree_array && scalar(@$pedigree_array) > 0 && scalar(@$pedigree_array[0]) > 0 ? @$pedigree_array[0] : undef;
             my $father = defined $pedigree_array && scalar(@$pedigree_array) > 1 ? @$pedigree_array[1] : undef;
             my $synonyms = $params->{synonyms} || [];
             my @synonymNames;


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Allowing germplasm being created via BrAPI to define only a male parent in the pedigree string.  Pedigree string will look like `/<male parent>`.


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
