### PR TITLE
[BI-1665] forcing autintication for observation is now parameter dirven.

### DIFF
--- a/lib/CXGN/BrAPI/v2/Observations.pm
+++ b/lib/CXGN/BrAPI/v2/Observations.pm
@@ -87,12 +87,11 @@ sub search {
         foreach (@$observations){
             my $observation_id = "$_->{phenotype_id}";
             # if ( ! $observation_db_id || grep{/^$observation_id$/} @{$observation_db_id} ){
-                my %season = {
+                my %season = (
                     year => $obs_unit->{year},
                     seasonName => $obs_unit->{year},
                     seasonDbId => $obs_unit->{year}
-                };
-
+                );
                 my $obs_timestamp = $_->{collect_date} ? $_->{collect_date} : $_->{timestamp};
                 if ( $start_time && $obs_timestamp < $start_time ) { next; } #skip observations before date range
                 if ( $end_time && $obs_timestamp > $end_time ) { next; } #skip observations after date range

--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -3815,7 +3815,7 @@ sub observations_PUT {
 	my $version = $c->request->captures->[0];
 	my $brapi_package_result;
 	if ($version eq 'v2'){
-		my $force_authenticate = 0;
+		my $force_authenticate = $c->config->{brapi_observations_require_login};
 		my ($auth,$user_id,$user_type) = _authenticate_user($c,$force_authenticate);
 	    my $clean_inputs = $c->stash->{clean_inputs};
 	    my %observations = %$clean_inputs;
@@ -3873,7 +3873,7 @@ sub observations_GET {
 sub observations_POST {
 	my $self = shift;
 	my $c = shift;
-    my $force_authenticate = 1;
+    my $force_authenticate = $c->config->{brapi_observations_require_login};
 	my ($auth,$user_id,$user_type) = _authenticate_user($c, $force_authenticate);
     my $clean_inputs = $c->stash->{clean_inputs};
     my $data = $clean_inputs;

--- a/sgn.conf
+++ b/sgn.conf
@@ -49,6 +49,8 @@ user_registration_join_breeding_programs 0  # when enabled, a new user can choos
 disable_login 0
 default_login_janedoe 0
 require_login 0
+
+brapi_observations_require_login 1
 brapi_require_login 0
 brapi_default_user admin
 brapi_GET any


### PR DESCRIPTION
# Description
[BI-1665](https://breedinginsight.atlassian.net/browse/BI-1665)


# Dependencies
bi-api:  feture/BI-1665 branch
bi-web: develop branch

# Set Up
in your _sgn_local.conf_ add the key-value pair:
`brapi_observations_require_login 0`

# Testing

1. Import an Experiments & Observation file with at least one phenotype column with the corresponding timestamp column(s).
2. Confirm the import.
3. Insure that the data has been saved in he backing BrAPI server  



Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.


[BI-1665]: https://breedinginsight.atlassian.net/browse/BI-1665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-1665]: https://breedinginsight.atlassian.net/browse/BI-1665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BI-1665]: https://breedinginsight.atlassian.net/browse/BI-1665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ