### PR TITLE
BI-1708 - Add support for External References for ObservationUnits in BreedBase

### DIFF
--- a/lib/CXGN/Trial/TrialDesignStore/PhenotypingTrial.pm
+++ b/lib/CXGN/Trial/TrialDesignStore/PhenotypingTrial.pm
@@ -36,7 +36,8 @@ sub BUILD {   # adjust the cvterm ids for phenotyping trials
         'subplots_names', #For splotplot
         'treatments', #For splitplot
         'subplots_plant_names', #For splitplot
-        'additional_info' # For brapi additional info storage
+        'additional_info', # For brapi additional info storage
+        'external_refs' # For brapi external reference storage
 	]);
 
 }


### PR DESCRIPTION
Description
-----------------------------------------------------
Added the ability to create `externalReferences` when creating `observationUnits`.

Previously the only way to add them was to create an OU first, then update it with the desired external references.

**Testing**
1. Create a new observation unit with external references via the POST /observationunits endpoint
2. Fetch the new OU via the GET /observationunits/{observationUnitDbId} endpoint and verify the external references included on the POST are returned on the GET


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
