### PR TITLE
BI-1710 - Add support for searching by externalReference to /search/trials endpoint in BreedBase

### DIFF
--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -1049,6 +1049,7 @@ sub trials_search_process {
 		searchDateRangeEnd  => $clean_inputs->{searchDateRangeEnd},
 		trialPUIs => $clean_inputs->{trialPUI},
 		externalReferenceIDs => $clean_inputs->{externalReferenceID},
+		externalReferenceIds => $clean_inputs->{externalReferenceId},
 		externalReferenceSources => $clean_inputs->{externalReferenceSource},
 		active  => $clean_inputs->{active},
 		commonCropNames  => $clean_inputs->{commonCropName},


### PR DESCRIPTION
Description
-----------------------------------------------------
Implemented the ability to specify `externalReferenceId(s)` and `externalReferenceSource(s)` for the `GET /trials` and `POST /search/trials` endpoints.

Testing
-----------------------------------------------------
1. Create a new trial with external references
2. make a call to the `GET /trials` endpoint, and specify `externalReferenceId` as a query param
3. Verify that only the trial with that `externalReferenceId` is returned

1. Create a new trial with external references
2. make a call to the `POST /search/trials` endpoint, and specify `externalReferenceIds` as a parameter in the body
3. make a call to the `GET /search/trials/{searchId}` endpoint
4. Verify that only the trial with that `externalReferenceId` is in the result set

Checklist
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [x] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
