### PR TITLE
BI-1705 - BreedBase Deploy fails when trying to execute run_all_patches

### DIFF
--- a/db/run_all_patches.pl
+++ b/db/run_all_patches.pl
@@ -46,7 +46,7 @@ my $db_patch_path = dirname(abs_path($0));
 chdir($db_patch_path);
 
 my @folders = grep /[0-9]{5}/, (split "\n", `ls -d */`);
-my $cmd = "echo -ne \"$dbpass\n\" | psql -h $host -U $dbuser -t -c \"select patch_name from Metadata.md_dbversion\" -d $db";
+my $cmd = "PGPASSWORD=$dbpass psql -h $host -U $dbuser -t -c \"select patch_name from Metadata.md_dbversion\" -d $db";
 my @installed = grep {!/^$/} map {s/^\s+|\s+$//gr} `$cmd`;
 
 for (my $i = 0; $i < (scalar @folders); $i++) {


### PR DESCRIPTION
Description
-----------------------------------------------------
When deploying BreedBase and running the run_all_patches.pl script, there was a prompt for the database password.  This has been fixed by changing how the password is set for the PSQL command


Checklist 
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
