### PR TITLE
BI-1609 (Add configuration to enable/disable PUT/POST /variables endpoints in Breedbase)

### DIFF
--- a/lib/CXGN/BrAPI/v2/ServerInfo.pm
+++ b/lib/CXGN/BrAPI/v2/ServerInfo.pm
@@ -18,6 +18,16 @@ sub search {
     $page_size = 1000;
 
 	my $status = $self->status;
+
+	# define the request methods for the 'variables' endpoints
+	my @variable_request_methods = ('GET');
+	if ($c->config->{brapi_put_variables}){
+		push @variable_request_methods, "PUT";
+	}
+	if ($c->config->{brapi_post_variables}){
+		push @variable_request_methods, "POST";
+	}
+
 	my @available = (
 		#core
 		[['application/json'],['GET'],'serverinfo',['2.0']],
@@ -71,7 +81,7 @@ sub search {
 		[['application/json'],['GET'], 'ontologies',['2.0']],
 		[['application/json'],['GET'], 'traits',['2.0']],
 		[['application/json'],['GET'], 'traits/{traitDbId}',['2.0']],
-		[['application/json'],['GET', 'POST','PUT'], 'variables',['2.0']],
+		[['application/json'],[\@variable_request_methods], 'variables',['2.0']],
 		[['application/json'],['GET'], 'variables/{observationVariableDbId}',['2.0']],
 		[['application/json'],['POST'],'search/variables',['2.0']],
 		[['application/json'],['GET'], 'search/variables/{searchResultsDbId}',['2.0']],

--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -2245,17 +2245,24 @@ sub studies_info_PUT {
 	_standard_response_construction($c, $brapi_package_result);
 }
 
-sub studies_observation_variables : Chained('studies_single') PathPart('observationvariables') Args(0) : ActionClass('REST') { }
+sub studies_observation_variables : Chained('studies_single') PathPart('observationvariables') Args(0) : ActionClass('REST') {
+	print( "2,.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,\n");
+	print( "2,.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,\n");
+}
 
 sub studies_observation_variables_POST {
 	my $self = shift;
 	my $c = shift;
+	print( ",.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,#.,.,.,.,.,.,\n");
+	print( ",.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,\n");
 	#my $auth = _authenticate_user($c);
 }
 
 sub studies_observation_variables_GET {
 	my $self = shift;
 	my $c = shift;
+	print( "3,.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,#.,.,.,.,.,.,\n");
+	print( "3,.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,\n");
 	my ($auth) = _authenticate_user($c);
 	my $brapi = $self->brapi_module;
 	my $brapi_module = $brapi->brapi_wrapper('Studies');
@@ -3294,6 +3301,8 @@ sub observationvariable_data_type_list : Chained('brapi') PathPart('variables/da
 sub observationvariable_data_type_list_POST {
 	my $self = shift;
 	my $c = shift;
+	print( "3,.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,\n");
+	print( "3,.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,\n");
 	#my $auth = _authenticate_user($c);
 }
 
@@ -3313,6 +3322,8 @@ sub observationvariable_ontologies : Chained('brapi') PathPart('ontologies') Arg
 sub observationvariable_ontologies_POST {
 	my $self = shift;
 	my $c = shift;
+	print( "4,.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,\n");
+	print( "4,.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,\n");
 	#my $auth = _authenticate_user($c);
 }
 
@@ -3390,11 +3401,19 @@ sub variables_search_retrieve : Chained('brapi') PathPart('search/variables') Ar
     retrieve_results($self, $c, $search_id, 'ObservationVariables');
 }
 
-sub observationvariable_list : Chained('brapi') PathPart('variables') Args(0) : ActionClass('REST') { }
+sub observationvariable_list : Chained('brapi') PathPart('variables') Args(0) : ActionClass('REST') {}
 
+# Endpoint for POST variables
 sub observationvariable_list_POST {
 	my $self = shift;
 	my $c = shift;
+
+	my $can_post_variables = $c->config->{brapi_post_variables};
+	if (not $can_post_variables){
+		my $error = CXGN::BrAPI::JSONResponse->return_error([], "Not configured to post Observation Variables");
+		_standard_response_construction($c, $error, 404);
+	}
+
 	my ($auth,$user_id) = _authenticate_user($c);
 
 	my $clean_inputs = $c->stash->{clean_inputs};
@@ -3466,11 +3485,18 @@ sub observationvariable_detail_GET {
 	_standard_response_construction($c, $brapi_package_result);
 }
 
+# Endpoint for PUT variables
 sub observationvariable_detail_PUT {
 	my $self = shift;
 	my $c = shift;
 	my $variableDbId = shift;
 	my ($auth,$user_id) = _authenticate_user($c);
+
+	my $can_put_variables = $c->config->{brapi_put_variables};
+	if (not $can_put_variables){
+		my $error = CXGN::BrAPI::JSONResponse->return_error([], "Not configured to update Observation Variables");
+		_standard_response_construction($c, $error, 404);
+	}
 
 	my $response;
 	try {

--- a/lib/SGN/Controller/AJAX/BrAPI.pm
+++ b/lib/SGN/Controller/AJAX/BrAPI.pm
@@ -2245,24 +2245,17 @@ sub studies_info_PUT {
 	_standard_response_construction($c, $brapi_package_result);
 }
 
-sub studies_observation_variables : Chained('studies_single') PathPart('observationvariables') Args(0) : ActionClass('REST') {
-	print( "2,.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,\n");
-	print( "2,.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,\n");
-}
+sub studies_observation_variables : Chained('studies_single') PathPart('observationvariables') Args(0) : ActionClass('REST') { }
 
 sub studies_observation_variables_POST {
 	my $self = shift;
 	my $c = shift;
-	print( ",.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,#.,.,.,.,.,.,\n");
-	print( ",.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,\n");
 	#my $auth = _authenticate_user($c);
 }
 
 sub studies_observation_variables_GET {
 	my $self = shift;
 	my $c = shift;
-	print( "3,.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,#.,.,.,.,.,.,\n");
-	print( "3,.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,\n");
 	my ($auth) = _authenticate_user($c);
 	my $brapi = $self->brapi_module;
 	my $brapi_module = $brapi->brapi_wrapper('Studies');
@@ -3301,8 +3294,6 @@ sub observationvariable_data_type_list : Chained('brapi') PathPart('variables/da
 sub observationvariable_data_type_list_POST {
 	my $self = shift;
 	my $c = shift;
-	print( "3,.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,\n");
-	print( "3,.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,\n");
 	#my $auth = _authenticate_user($c);
 }
 
@@ -3322,8 +3313,6 @@ sub observationvariable_ontologies : Chained('brapi') PathPart('ontologies') Arg
 sub observationvariable_ontologies_POST {
 	my $self = shift;
 	my $c = shift;
-	print( "4,.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,\n");
-	print( "4,.,.,.,.,.,.,,.,.,.,.,.,,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,.,\n");
 	#my $auth = _authenticate_user($c);
 }
 
@@ -3401,7 +3390,7 @@ sub variables_search_retrieve : Chained('brapi') PathPart('search/variables') Ar
     retrieve_results($self, $c, $search_id, 'ObservationVariables');
 }
 
-sub observationvariable_list : Chained('brapi') PathPart('variables') Args(0) : ActionClass('REST') {}
+sub observationvariable_list : Chained('brapi') PathPart('variables') Args(0) : ActionClass('REST') { }
 
 # Endpoint for POST variables
 sub observationvariable_list_POST {

--- a/sgn.conf
+++ b/sgn.conf
@@ -53,6 +53,8 @@ default_login_janedoe 0
 require_login 0
 
 brapi_observations_require_login 1
+brapi_post_variables 0
+brapi_put_variables  0
 brapi_require_login 0
 brapi_default_user admin
 brapi_GET any


### PR DESCRIPTION
[BI-1609 ](https://breedinginsight.atlassian.net/browse/BI-1609)
Add configuration to enable/disable PUT/POST /variables endpoints in Breedbase
-----------------------------------------------------

**TESTING**

1. GIVEN: You set the configuration variables _brapi_post_variables_  and _brapi_put_variables_to 0.
2. WHEN: You attempt to POST observation variable data
3. THEN: You receive a 404 (Not Found) error
4. WHEN: You attempt to update (PUT) observation variable data
5. THEN: You receive a 404 (Not Found) error
6. WHEN: You go to the Server Info endpoint 
```
curl --request GET \
--url http://localhost:7080/brapi/v2/serverinfo \
--header 'Content-Type: application/json'
```
7. THEN: The variables service should only show the "GET" method
`			{
"datatypes": [
"application/json"
],
"versions": [
"2.0"
],
"methods": [
[
"GET"
]
],
"service": "variables"
},`

8. GIVEN: You set the configuration variables _brapi_post_variables_  and _brapi_put_variables_to 0.
9. WHEN: You attempt to POST observation variable data
10. THEN: The endpoint should be found (the post should succeed or an error, other that a 404 error, should be displayed)
11. WHEN: You attempt to update (PUT) observation variable data
12. THEN: The endpoint should be found (the put should succeed or an error, other that a 404 error, should be displayed)
13. WHEN: You go to the Server Info endpoint 
```
curl --request GET \
--url http://localhost:7080/brapi/v2/serverinfo \
--header 'Content-Type: application/json'
```
7. THEN: The variables service should show the "GET", "POST", and "PUT" methods
`			{
"datatypes": [
"application/json"
],
"versions": [
"2.0"
],
"methods": [
[
"GET",
"POST",
"PUT"
]
],
"service": "variables"
},`



Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [ ] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
