### PR TITLE
Feature/bi 1193

### DIFF
--- a/lib/CXGN/BrAPI/v2/Lists.pm
+++ b/lib/CXGN/BrAPI/v2/Lists.pm
@@ -207,7 +207,7 @@ sub detail {
 
 	 	my $rs = $people_schema->resultset("SpPerson")->search( { %query });
 		my $owner_name;
-		
+
 		while (my $p = $rs->next()) {
 			$owner_name = $p->first_name() . " " . $p->last_name();
 		}
@@ -308,7 +308,7 @@ sub store {
 	    my $validated = $lv->validate($schema, $list_type, $data);
 	    my $missing = scalar(@{$validated->{missing}});
 	    if ($missing > 0){
-		    return CXGN::BrAPI::JSONResponse->return_error($self->status, sprintf('Data must have valid items existing in the database!'));	    	
+		    return CXGN::BrAPI::JSONResponse->return_error($self->status, sprintf('Data must have valid items existing in the database!'));
 	    }
 		#create list
     	my $new_list_id = CXGN::List::create_list($dbh, $list_name, $list_description, $owner_id);
@@ -425,7 +425,7 @@ sub update {
 	    my $validated = $lv->validate($schema, $list_type, $data);
 	    my $missing = scalar(@{$validated->{missing}});
 	    if ($missing > 0){
-		    return CXGN::BrAPI::JSONResponse->return_error($self->status, sprintf('Data must have valid items existing in the database!'));	    	
+		    return CXGN::BrAPI::JSONResponse->return_error($self->status, sprintf('Data must have valid items existing in the database!'));
 	    }
 	    my $response = $list->add_bulk($data);
 	    if ($response->{error}) {
@@ -461,7 +461,7 @@ sub update {
   	my @data_files;
 	my $pagination = CXGN::BrAPI::Pagination->pagination_response($counter,$page_size,$page);
 
-	return CXGN::BrAPI::JSONResponse->return_success(1, $pagination, \@data_files, $status, $counter . ' Lists stored');
+	return $self->detail($list_id);
 
 }
 
@@ -497,7 +497,7 @@ sub store_items {
     my $validated = $lv->validate($schema, $list->{type}, $data);
     my $missing = scalar(@{$validated->{missing}});
     if ($missing > 0){
-	    return CXGN::BrAPI::JSONResponse->return_error($self->status, sprintf('Data must have valid items existing in the database!'));	    	
+	    return CXGN::BrAPI::JSONResponse->return_error($self->status, sprintf('Data must have valid items existing in the database!'));
     }
     my $response = $list->add_bulk($data);
     if ($response->{error}) {
@@ -507,7 +507,8 @@ sub store_items {
   	my @data_files;
 	my $pagination = CXGN::BrAPI::Pagination->pagination_response($counter,$page_size,$page);
 
-	return CXGN::BrAPI::JSONResponse->return_success(1, $pagination, \@data_files, $status,'Lists stored');
+  	return $self->detail($list_id);
+
 
 }
 1;

--- a/lib/CXGN/List/Validate/Plugin/Traits.pm
+++ b/lib/CXGN/List/Validate/Plugin/Traits.pm
@@ -22,11 +22,14 @@ sub validate {
 # For postcomposed terms expects full trait names e.g. tissue metabolite unit time|COMP:0000015
 
     foreach my $term (@$list) {
-        #print STDERR $term."\n";
+        print STDERR $term."\n";
 
+        #if (index($term, '|') ) {
+
+        #}
         my @parts = split (/\|/ , $term);
         my ($db_name, $accession) = split ":", pop @parts;
-        my $trait_name = join '|', @parts;
+        my $trait_name = $term;
 
         $accession =~ s/\s+$//;
         $accession =~ s/^\s+//;
@@ -35,16 +38,30 @@ sub validate {
         $trait_name =~ s/\s+$//;
         $trait_name =~ s/^\s+//;
 
+        print STDERR $db_name."\n";
+        print STDERR $trait_name."\n";
+        if ($db_name eq '' || $db_name eq $trait_name) {
+          my $context = SGN::Context->new;
+          #my $cv_name = $context->get_conf('trait_ontology_cv_name');
+          #my $cvterm_name = $context->get_conf('trait_ontology_cvterm_name');
+          $db_name = $context->get_conf('trait_ontology_db_name');
+        }
+
         my $db_rs = $schema->resultset("General::Db")->search( { 'me.name' => $db_name });
         if ($db_rs->count() == 0) {
-            #print STDERR "Problem found with term $term at db $db_name\n";
+            print STDERR "Problem found with term $term at db $db_name\n";
             push @missing, $term;
         } else {
             my $db = $db_rs->first();
             my $query = {
                 'dbxref.db_id' => $db->db_id(),
-                'dbxref.accession' => $accession,
             };
+
+            if ($accession eq '') {
+                $query->{'me.name'} = $trait_name;
+            } else {
+                $query->{'dbxref.accession'} = $accession;
+            }
             if ( $db_name eq 'COMP' && $validator->{composable_validation_check_name} ) {
                 $query->{'me.name'} = $trait_name;
             }
@@ -52,13 +69,13 @@ sub validate {
 
             my $is_missing = 0;
             if ($rs->count == 0) {
-                #print STDERR "Problem found with term $term at cvterm rs from accession $accession point 2\n";
+                print STDERR "Problem found with term $term at cvterm rs from accession $accession point 2\n";
                 push @missing, $term;
                 $is_missing = 1;
             } else {
                 my $rs_var = $rs->search_related('cvterm_relationship_subjects', {'type.name' => 'VARIABLE_OF'}, { 'join' => 'type'});
                 if ($rs_var->count == 0) {
-                    #print STDERR "Problem found with term $term at variable check point 3\n";
+                    print STDERR "Problem found with term $term at variable check point 3\n";
                     push @missing, $term;
                     $is_missing = 1;
                 }
@@ -89,7 +106,7 @@ sub validate {
         }
 
     }
-    # print STDERR Dumper \@missing;
+    print STDERR Dumper \@missing;
     print STDERR Dumper \@wrong_ids;
     return {
         missing => \@missing,


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
While making backend changes to Delatbreed for [BI-1193](https://breedinginsight.atlassian.net/jira/software/c/projects/BI/boards/1?modal=detail&selectedIssue=BI-1193) some non-brapi-compliant parts of how lists are handled in Breedbase had to be partially addressed for the Deltabreed feature to work with Breeddbase.
- BrAPI spec requires list data to be an array of dbids; however, Breedbase uses specially formatted unique names instead of ids.  When updating lists, the Breedbase validator will reject strings that don't follow the name format.
- when updating a list or list data, a number 1 is returned in the response instead of a json rep of the list object as per the BrAPI spec

Changes:
- Deltabreed was changed to store observation variable names with prog key instead of dbid
- the BB validator was changed to pass obsvar names in the deltabreed format
- the json object of the list is returned for updates to list and list data

Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [x] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.


[BI-1193]: https://breedinginsight.atlassian.net/browse/BI-1193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ