### PR TITLE
BI-1752 & BI-1753 - Breedbase Field Book file export and import fixes

### DIFF
--- a/lib/CXGN/Phenotypes/StorePhenotypes.pm
+++ b/lib/CXGN/Phenotypes/StorePhenotypes.pm
@@ -371,10 +371,6 @@ sub verify {
                 my $trait_cvterm_id = $trait_cvterm->cvterm_id();
                 my $stock_id = $schema->resultset('Stock::Stock')->find({'uniquename' => $plot_name})->stock_id();
 
-                if ($trait_value eq '.' || ($trait_value =~ m/[^a-zA-Z0-9,.\-\/\_]/ && $trait_value ne '.')){
-                    $error_message = $error_message."<small>Trait values must be alphanumeric with no spaces: <br/>Plot Name: ".$plot_name."<br/>Trait Name: ".$trait_name."<br/>Value: ".$trait_value."</small><hr>";
-                }
-
                 #check that trait value is valid for trait name
                 if (exists($check_trait_format{$trait_cvterm_id})) {
                     if ($check_trait_format{$trait_cvterm_id} eq 'numeric') {

--- a/sgn.conf
+++ b/sgn.conf
@@ -443,5 +443,5 @@ authorized_clients_JSON {"TEST://":"TEST","fieldbook://":"FieldBook App","https:
 
 simsearch_datadir /home/production/simsearch_data
 
-version sgn-350.0-256
+version sgn-350.0-260
 version_updated 2021-12-23T19:04:41Z


### PR DESCRIPTION
- [Removed alphanumeric constraint for phenotype verification](https://github.com/Breeding-Insight/sgn/pull/117/commits/ad90d176293bea8837dac761197d9b233ef8d12b)
- [Added conversion for brapi datatypes and categories](https://github.com/Breeding-Insight/sgn/pull/117/commits/b8a8e56686c9e039ec2566c0565d00c3b0501895)

Maintained backwards compatibility with existing breedbase field updates. May be a problem if we name traits certain ways so something to be aware of.