### PR TITLE
[BI-1797] - Experiment & Observations import errors (BreedBase)

### DIFF
--- a/lib/CXGN/BrAPI/v2/Studies.pm
+++ b/lib/CXGN/BrAPI/v2/Studies.pm
@@ -340,12 +340,13 @@ sub store {
 				return { error => $references->{'error'} };
 			}
 		}
-
-
 	}
 
 	my $data_out;
 	my $total_count=0;
+	# This is servicing a POST request, make sure pagination returns all created objects.
+	$page_size = scalar(@study_dbids);
+	$page = 0;
 	if (scalar(@study_dbids)>0){
 		my $dbh = $c->dbc->dbh();
 		my $bs = CXGN::BreederSearch->new( { dbh=>$dbh, dbname=>$c->config->{dbname}, } );

--- a/lib/CXGN/Phenotypes/ParseUpload/Plugin/Observations.pm
+++ b/lib/CXGN/Phenotypes/ParseUpload/Plugin/Observations.pm
@@ -224,14 +224,6 @@ sub parse {
         return \%parse_result;
     }
 
-    foreach my $value (@values) {
-        if ($value eq '.' || ($value =~ m/[^a-zA-Z0-9,.\-\/\_:;\s]/ && $value ne '.')) {
-            $parse_result{'error'} = "Value $value is not valid. Trait values must be alphanumeric.";
-            print STDERR "Invalid value: $value\n";
-            return \%parse_result;
-        }
-    }
-
     foreach my $timestamp (@timestamps) {
         if (!$timestamp =~ m/(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(\S)(\d{4})/) {
             $parse_result{'error'} = "Timestamp $timestamp is not of form YYYY-MM-DD HH:MM:SS-0000 or YYYY-MM-DD HH:MM:SS+0000";


### PR DESCRIPTION
Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
[Here's the bug on Jira](https://breedinginsight.atlassian.net/browse/BI-1797).

There were 2 bugs preventing Experiment & Observation imports from DeltaBreed to BreedBase.
1. BreedBase was only allowing certain characters in Trait (Observation) value field when POSTing via BrAPI, I removed this constraint in `lib/CXGN/Phenotypes/ParseUpload/Plugin/Observations.pm`. Relates to https://github.com/Breeding-Insight/sgn/pull/117/files.
2. BreedBase was paginating its response to POST requests to the /studies endpoint, so not all created objects would be contained in the response, which is inconsistent with the BrAPI spec. I changed the pagination behavior to return all created objects, see  `lib/CXGN/BrAPI/v2/Studies.pm`.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [ ] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
