### PR TITLE
[BI-1193] BI-API throws timeout exception when BB mat view refresh exceeds 10m

### DIFF
--- a/lib/CXGN/BrAPI/v2/ObservationUnits.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationUnits.pm
@@ -853,7 +853,7 @@ sub _refresh_matviews {
     my $bs = CXGN::BreederSearch->new( { dbh=>$dbh, dbname=>$c->config->{dbname}, } );
 
     # Refresh materialized view so data can be retrieved
-    my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'phenotypes', 'concurrent', $c->config->{basepath});
+    my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'phenotypes', 'concurrent', $c->config->{basepath}, 0);
     # Wait until materialized view is reset. Wait 5 minutes total, then throw an error
     my $refreshing = 1;
     my $refresh_time = 0;

--- a/lib/CXGN/BrAPI/v2/ObservationUnits.pm
+++ b/lib/CXGN/BrAPI/v2/ObservationUnits.pm
@@ -853,21 +853,7 @@ sub _refresh_matviews {
     my $bs = CXGN::BreederSearch->new( { dbh=>$dbh, dbname=>$c->config->{dbname}, } );
 
     # Refresh materialized view so data can be retrieved
-    my $refresh = $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'phenotypes', 'concurrent', $c->config->{basepath}, 0);
-    # Wait until materialized view is reset. Wait 5 minutes total, then throw an error
-    my $refreshing = 1;
-    my $refresh_time = 0;
-    while ($refreshing && $refresh_time < $timeout) {
-        my $refresh_status = $bs->matviews_status();
-        if (!$refresh->{connection}->alive) {
-            $refreshing = 0;
-        } elsif ($refresh_time >= $timeout) {
-            return {error => CXGN::BrAPI::JSONResponse->return_error($self->status, "Refreshing materialized views is taking too long to return a response", 500)};
-        } else {
-            sleep 1;
-            $refresh_time += 1;
-        }
-    }
+    $bs->refresh_matviews($c->config->{dbhost}, $c->config->{dbname}, $c->config->{dbuser}, $c->config->{dbpass}, 'phenotypes', 'concurrent', $c->config->{basepath}, 0);
 }
 
 sub _order {


### PR DESCRIPTION


Description <!-- Describe your changes in detail. -->
-----------------------------------------------------
Importing of experiments was failing during QA because the volume of data (for example, ~100,00 germplasm) was causing the time to refresh the phenotype materialized view after obs. unit creation to exceed the limit set in bi-api (10 minutes) when a timeout exception is thrown if it hasn't received a response from the brapi service.

The call to refresh the mat. view was changed from asynchronous to synchronous to avoid potential race conditions.

<!-- If there are relevant issues, link them here: -->


Checklist <!-- Put an `x` in all the boxes that apply, or check them once submitted.-->
---------------------------------------------------------------------------------------
- [ ] Refactoring only
- [ ] Documentation only
- [ ] Fixture update only
- [x] Bug fix
  - [ ] The relevant issue has been closed.
  - [x] Further work is required.
- [ ] New feature
  - [ ] Relevant tests have been created and run.
  - [ ] Data was added to the fixture
    - [ ] Data was added via a patch in `/t/data/fixture/patches/`.
  - [ ] User-Facing Change
    - [ ] The user manual in `/docs` has been updated.
  - [ ] Any new Perl has been documented using **perldoc**.
  - [ ] Any new JavaScript has been documented using **JSDoc**.
  - [ ] Any new _legacy_ JavaScript has been moved from `/js` to `/js/source/legacy`.
